### PR TITLE
Fix for shbang line

### DIFF
--- a/autojump
+++ b/autojump
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #Copyright Joel Schaerer 2008-2010
 #This file is part of autojump
 


### PR DESCRIPTION
This just changes the shbang line to /usr/bin/env python

Without this, autojump doesnt work on FreeBSD because python is in /usr/local/bin on FreeBSD
