### PR TITLE
Combining cd and ls into j function.

### DIFF
--- a/autojump.bash
+++ b/autojump.bash
@@ -45,6 +45,6 @@ fi
 AUTOJUMP='{ [[ "$AUTOJUMP_HOME" == "$HOME" ]] && (autojump -a "$(pwd -P)"&)>/dev/null 2>>${AUTOJUMP_DATA_DIR}/autojump_errors;} 2>/dev/null'
 if [[ ! $PROMPT_COMMAND =~ autojump ]]; then
   export PROMPT_COMMAND="${PROMPT_COMMAND:-:} ; $AUTOJUMP"
-fi 
+fi
 alias jumpstat="autojump --stat"
-function j { new_path="$(autojump $@)";if [ -n "$new_path" ]; then echo -e "\\033[31m${new_path}\\033[0m"; cd "$new_path";else false; fi }
+function j { new_path="$(autojump $@)";if [ -n "$new_path" ]; then echo -e "\\033[31m${new_path}\\033[0m"; cd "$new_path" && ls;else false; fi }


### PR DESCRIPTION
If you analyze most users' command line history files, `cd` and `ls` usually top the list.  For example my laptop's top 10 shell commands:

<pre>   1993 ls
   1334 cd
    445 g #alias for git
    418 sudo
    278 ssh
    276 git
    223 vim
    215 rm
    139 v #alias for vim
    126 mv</pre>


The default behavior for most users is to `ls` right after `cd` to the point that I have a function cl that basicly duplicates this behavior.
