### PR TITLE
Change default install location to /usr/local/, deletes old files in /usr/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,9 +104,9 @@ before the first step.
 
 Manual installation of autojump is very simple: copy
 
-- autojump to /usr/bin,
+- autojump to /usr/local/bin,
 - autojump.sh to /etc/profile.d,
-- autojump.1 to /usr/share/man/man1.
+- autojump.1 to /usr/local/share/man/man1.
 
 Make sure to source ``/etc/profile`` in your ``.bashrc`` or ``.zshrc`` ::
 
@@ -136,15 +136,15 @@ To completely remove autojump you should remove these files:
 
 ``/etc/profile.d/autojump.zsh``
 
-``/usr/bin/autojump``
+``/usr/local/bin/autojump``
 
-``/usr/bin/jumpapplet``
+``/usr/local/bin/jumpapplet``
 
-``/usr/share/autojump/icon.png``
+``/usr/local/share/autojump/icon.png``
 
-``/usr/share/autojump/``
+``/usr/local/share/autojump/``
 
-``/usr/share/man/man1/autojump.1``
+``/usr/local/share/man/man1/autojump.1``
 
 Remove any mention of autojump in your ``.bashrc`` or ``.zshrc``, then in currently running shells do:``source /etc/profile``.
 

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ function show_help {
 }
 
 # Default install directory.
-prefix=/usr
+prefix=/usr/local
 
 # Command line parsing
 while true; do
@@ -37,6 +37,26 @@ while true; do
       *)  break;;
     esac
 done
+
+uninstall=0;
+if [ -f "/usr/bin/autojump" ]; then
+    while true; do
+        read -p "Old installation detected, remove? [Yn] " yn
+        case $yn in
+            [Yy]* ) uninstall=1; break;;
+            [Nn]* ) "Already installed, exiting." exit 1;;
+            * ) uninstall=1; break;;
+        esac
+    done
+fi
+
+if [ ${uninstall} == 1 ]; then
+    echo "Deleting old installation files ..."
+    sudo rm -r /usr/share/autojump/
+    sudo rm /usr/bin/autojump
+    sudo rm /usr/bin/jumpapplet
+    sudo rm /usr/share/man/man1/autojump.1
+fi
 
 echo "Installing to ${prefix} ..."
 
@@ -69,12 +89,12 @@ else
     echo "Your distribution does not have a /etc/profile.d directory, the default that we install one of the scripts to. Would you like us to copy it into your ~/.bashrc file to make it work? (If you have done this once before, delete the old version before doing it again.) [y/n]"
     read ans
     if [ ${#ans} -gt 0 ]; then
-	     if [ $ans = "y" -o $ans = "Y" -o $ans = "yes" -o $ans = "Yes" ]; then
+         if [ $ans = "y" -o $ans = "Y" -o $ans = "yes" -o $ans = "Yes" ]; then
 
                 # Answered yes. Go ahead and add the autojump code
-	        echo "" >> ~/.bashrc
-	        echo "#autojump" >> ~/.bashrc
-	        cat autojump.bash | grep -v "^#" >> ~/.bashrc
+            echo "" >> ~/.bashrc
+            echo "#autojump" >> ~/.bashrc
+            cat autojump.bash | grep -v "^#" >> ~/.bashrc
 
                 # Since OSX uses .bash_profile, we need to make sure that .bashrc is properly sourced.
                 # Makes the assumption that if they have a line: source ~/.bashrc or . ~/.bashrc, that
@@ -87,9 +107,9 @@ else
                     echo -e "if [ -f ~/.bashrc ]; then\n  . ~/.bashrc\nfi" >> ~/.bash_profile
                 fi
                 echo "You need to source your ~/.bashrc (source ~/.bashrc) before you can start using autojump."
-	     else
-	         echo "Then you need to put autojump.sh, or the code from it, somewhere where it will get read. Good luck!"
-	     fi
+         else
+             echo "Then you need to put autojump.sh, or the code from it, somewhere where it will get read. Good luck!"
+         fi
     else
         echo "Then you need to put autojump.sh, or the code from it, somewhere where it will get read. Good luck!"
     fi

--- a/jumpapplet
+++ b/jumpapplet
@@ -168,7 +168,7 @@ def settings(sender):
     window.set_border_width(3)
     window.set_resizable(False)
     if os.path.isfile("icon.png"): window.set_icon_from_file("icon.png")
-    elif os.path.isfile("/usr/share/autojump/icon.png"): window.set_icon_from_file("/usr/share/autojump/icon.png")
+    elif os.path.isfile("/usr/local/share/autojump/icon.png"): window.set_icon_from_file("/usr/local/share/autojump/icon.png")
 
     vbox=gtk.Table(5,2)
     vbox.set_row_spacings(3)
@@ -234,7 +234,7 @@ def save_settings(sender,response,entries,window):
 def init():
     load_settings_file()
     if os.path.isfile("icon.png"): icon=gtk.status_icon_new_from_file("icon.png")
-    elif os.path.isfile("/usr/share/autojump/icon.png"): icon=gtk.status_icon_new_from_file("/usr/share/autojump/icon.png")
+    elif os.path.isfile("/usr/local/share/autojump/icon.png"): icon=gtk.status_icon_new_from_file("/usr/local/share/autojump/icon.png")
     else: icon=gtk.status_icon_new_from_icon_name("help")
     icon.set_visible(True)
     icon.connect("popup-menu",popup)


### PR DESCRIPTION
Implemented request in [Issue 16](https://github.com/joelthelion/autojump/issues/16) for bash only.

Detects if /usr/bin/autojump exists, and if so prompts user and deletes necessary files out of /usr/bin/ and /usr/share/.

This pull request also includes the earlier pull request regarding the [grep fix](https://github.com/joelthelion/autojump/pull/46#issuecomment-1052444).
