### PR TITLE
Add existence test for installed profile.d bash setup.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,9 @@ if [ -d "/etc/profile.d" ]; then
         echo "Adding the /etc/profile.d/autojump.bash to your .bashrc"
         echo "" >> ~/.bashrc
         echo "# Added by autojump install.sh" >> ~/.bashrc
-        echo "source /etc/profile.d/autojump.bash" >> ~/.bashrc
+        echo "if [ -f /etc/profile.d/autojump.bash ]; then" >> ~/.bashrc
+        echo "    source /etc/profile.d/autojump.bash" >> ~/.bashrc
+        echo "fi" >> ~/.bashrc
     fi
     echo "Done!"
     echo


### PR DESCRIPTION
Change install.sh to guard against sourcing non-existant autojump.bash.  Necessary when the home directory may be mounted on multiple systems, some of which may not have autojump installed.
