### PR TITLE
Use pickle protocol 2.

### DIFF
--- a/autojump
+++ b/autojump
@@ -53,7 +53,7 @@ def save(path_dict, dic_file):
     # Otherwise, fail quietly
     if (not os.path.exists(dic_file)) or os.getuid() == os.stat(dic_file)[4]:
         temp = NamedTemporaryFile(dir=CONFIG_DIR, delete=False)
-        pickle.dump(path_dict, temp, -1)
+        pickle.dump(path_dict, temp, 2)
         temp.flush()
         os.fsync(temp)
         temp.close()


### PR DESCRIPTION
virtualenv is able to change the version of the 'default' python interpreter. In particular I use it to switch between python 2 and 3 on my setup. However, python 2 isn't able to read the latest version of the pickle file format, so autojump fails whenever I switch over. This change ensures that autojump uses the backwards-compatible pickle format.

Existing users should not notice anything -- if they are using python 3 and their dic_file is currently in version 3, autojump will be able to open it as usual, but it will save the file in the version 2 format.
