### PR TITLE
Fix install.sh to check for sourcing of .bashrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ else
                 # Makes the assumption that if they have a line: source ~/.bashrc or . ~/.bashrc, that
                 # .bashrc has been properly sourced and you don't need to add it.
                 OS=`uname`
-                if [ $OS == 'Darwin' -a `grep -c "^[[:space:]]*\(source\|\.\) /etc/profile\(\.d/autojump\.bash\)[[:space:]]*$" ~/.bash_profile` -eq 0 ]; then
+                if [ $OS == 'Darwin' -a `grep -c "^[[:space:]]*\(source\|\.\) ~/\.bashrc[[:space:]]*$" ~/.bash_profile` -eq 0 ]; then
                     echo "You are using OSX and your .bash_profile doesn't seem to be sourcing .bashrc"
                     echo "Adding source ~/.bashrc to your bashrc"
                     echo -e "\n# Get the aliases and functions" >> ~/.bash_profile


### PR DESCRIPTION
`install.sh` says that it checks to see if `~/.bash_profile` sources `~/.bashrc` on OS X, but the regular expression in the file instead checks for the `/etc/profile.d/autojump.bash`. The attached commit changes this regular expression.
