### PR TITLE
Fix PROMPT_COMMAND for compatibility with OS X Lion

### DIFF
--- a/autojump.bash
+++ b/autojump.bash
@@ -44,7 +44,7 @@ fi
 
 AUTOJUMP='{ [[ "$AUTOJUMP_HOME" == "$HOME" ]] && (autojump -a "$(pwd -P)"&)>/dev/null 2>>${AUTOJUMP_DATA_DIR}/autojump_errors;} 2>/dev/null'
 if [[ ! $PROMPT_COMMAND =~ autojump ]]; then
-  export PROMPT_COMMAND="${PROMPT_COMMAND:-:} ; $AUTOJUMP"
+  export PROMPT_COMMAND="$AUTOJUMP ; ${PROMPT_COMMAND:-:}"
 fi 
 alias jumpstat="autojump --stat"
 function j { new_path="$(autojump $@)";if [ -n "$new_path" ]; then echo -e "\\033[31m${new_path}\\033[0m"; cd "$new_path";else false; fi }


### PR DESCRIPTION
Instead of updating $PROMPT_COMMAND by appending $AUTOJUMP with a leading
semicolon, prepend $AUTOJUMP followed by a semicolon.

It is unlikely (and frankly wrong) for anything to set $PROMPT_COMMAND to
begin with a semicolon, so this modification should not cause conflicts
where the previous version does.
