### PR TITLE
I added a fix for missing getent on osx

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,12 @@ function show_help {
 prefix=/usr
 
 user=${SUDO_USER:-${USER}}
+OS=`uname`
+if [ $OS == 'Darwin' ]; then
+user_home=$(dscl . -search /Users UniqueID ${user} | cut -d: -f6)
+else
 user_home=$(getent passwd ${user} | cut -d: -f6)
+fi
 bashrc_file=${user_home}/.bashrc
 
 # Command line parsing


### PR DESCRIPTION
Found it here: http://zzamboni.org/brt/2008/01/21/how-to-emulate-unix-getent-with-macosxs-dscl/
