### PR TITLE
Local installation (z-shell)

### DIFF
--- a/autojump
+++ b/autojump
@@ -93,7 +93,7 @@ def save(path_dict, dic_file):
         # using rename to overwrite files
         shutil.move(temp.name, dic_file)
         try: #backup file
-            import time 
+            import time
             if (not os.path.exists(dic_file+".bak") or
                     time.time()-os.path.getmtime(dic_file+".bak")>86400):
                 shutil.copy(dic_file, dic_file+".bak")
@@ -147,14 +147,14 @@ def open_dic(dic_file, error_recovery=False):
 def forget(path_dict, dic_file):
     """Gradually forget about directories. Only call
     from the actual jump since it can take time"""
-    keyweight = sum(path_dict.values()) 
-    if keyweight > MAX_KEYWEIGHT: 
+    keyweight = sum(path_dict.values())
+    if keyweight > MAX_KEYWEIGHT:
         for k in path_dict.keys():
             path_dict[k] *= 0.9 * MAX_KEYWEIGHT / keyweight
         save(path_dict, dic_file)
 
 def clean_dict(sorted_dirs, path_dict):
-    """Limits the sized of the path_dict to MAX_STORED_PATHS. 
+    """Limits the sized of the path_dict to MAX_STORED_PATHS.
     Returns True if keys were deleted"""
     if len(sorted_dirs) > MAX_STORED_PATHS:
         #remove 25 more than needed, to avoid doing it every time
@@ -183,7 +183,7 @@ def match(path, pattern, ignore_case=False, only_end=False):
     return (does_match, eaten_path)
 
 def find_matches(dirs, patterns, result_list, ignore_case, max_matches, current_dir):
-    """Find max_matches paths that match the pattern, 
+    """Find max_matches paths that match the pattern,
     and add them to the result_list"""
     for path, count in dirs:
         # Don't jump to where we alread are
@@ -222,7 +222,7 @@ def shell_utility():
     if ('-a', '') in optlist:
         # The home dir can be reached quickly by "cd"
         # and may interfere with other directories
-        if(args[-1] != os.path.expanduser("~")): 
+        if(args[-1] != os.path.expanduser("~")):
             dicadd(path_dict, decode(args[-1]))
             save(path_dict, dic_file)
     elif ('--stat', '') in optlist:
@@ -241,7 +241,7 @@ def shell_utility():
         import re
         completion = False
         #userchoice is i if the pattern is __pattern__i, otherwise -1
-        userchoice = -1 
+        userchoice = -1
         results = []
         if ('--completion', '') in optlist:
             completion = True
@@ -286,10 +286,10 @@ def shell_utility():
             find_matches(dirs, patterns, results, False, max_matches, current_dir)
             # If not found, try ignoring case.
             # On completion always show all results
-            if completion or not results: 
+            if completion or not results:
                 find_matches(dirs, patterns, results,
                         ignore_case=True,
-                        max_matches=max_matches, current_dir=current_dir) 
+                        max_matches=max_matches, current_dir=current_dir)
             # Keep the database to a reasonable size
             if not completion and clean_dict(dirs, path_dict):
                 save(path_dict, dic_file)
@@ -298,7 +298,7 @@ def shell_utility():
             else: quotes = ""
 
             if userchoice != -1:
-                if len(results) > userchoice-1 : 
+                if len(results) > userchoice-1 :
                     output(unico("%s%s%s") % (quotes,results[userchoice-1],quotes))
             elif len(results) > 1 and completion:
                 output("\n".join(("%s%s%d%s%s" % (patterns[-1],

--- a/install.zsh
+++ b/install.zsh
@@ -57,7 +57,7 @@ while true; do
 	esac
 done
 
-if [[ $(whoami) != "root" ]] && ! ${local}; then
+if [[ ${UID} != 0 ]] && ! ${local}; then
 	echo "Please rerun as root or use the --local option."
 	exit 1
 fi


### PR DESCRIPTION
This is regarding [issue #50](https://github.com/joelthelion/autojump/issues/50).
1. If `install.zsh` is run as root, it installs globally (old behavior).
2. If `install.zsh` is run as non-root, quits with error message.
3. If `install.zsh --local` is run, installs it locally.

When installing locally, defaults to `~/.autojump/` unless overwritten by user using the `--prefix` option. It puts all files required for autojump in a single folder for easy removal, and outputs relevant `~/.zshrc` changes for user to manually edit.

There are also some minor formatting/wording changes.

If these changes garner interest and gets merged into the master repo, some other changes I'd do:
- modify `uninstall.zsh` to detect and remove local installs
- test if `~/.zshrc` has been modified appropriately and adds changes if not
- make relevant tweaks to support z-shell on Mac OS X
- rewrite the bash equivalent `install.sh` and `uninstall.sh` files to match.
