### PR TITLE
bash: local installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ function show_help {
 
 # Default install directory.
 prefix=/usr
-local=0
+local=
 
 user=${SUDO_USER:-${USER}}
 OS=`uname`
@@ -41,14 +41,13 @@ while true; do
             exit 0
             ;;
         -l|--local)
-            local=1
+            local=true
             prefix=~/.autojump
             shift
             ;;
         -p|--prefix)
             if [ $# -gt 1 ]; then
                 prefix=$2; shift 2
-                profile_d=$prefix/etc/autojump
             else
                 die "--prefix or -p require an argument"
             fi
@@ -73,7 +72,7 @@ if [[ ${UID} != 0 ]] && [ ! ${local} ]; then
     exit 1
 fi
 
-echo "Installing main files to ${prefix} ..."
+echo -e "Installing files to ${prefix} ...\n"
 
 # add git revision to autojump
 ./git-version.sh
@@ -92,44 +91,17 @@ if [ ! ${local} ]; then
         cp -v autojump.bash /etc/profile.d/
         cp -v autojump.sh /etc/profile.d/
 
-        # Make sure that the code we just copied has been sourced.
-        # check if .bashrc has sourced /etc/profile or /etc/profile.d/autojump.bash
-        if [ `grep -c "^[[:space:]]*\(source\|\.\) /etc/profile\(\.d/autojump\.bash\)[[:space:]]*$" ${bashrc_file}` -eq 0 ]; then
-            echo "Your .bashrc doesn't seem to source /etc/profile or $profile_d/autojump.bash"
-            echo "Adding the /etc/profile.d/autojump.bash to your .bashrc"
-            echo "" >> ${bashrc_file}
-            echo "# Added by autojump install.sh" >> ${bashrc_file}
-            echo "source /etc/profile.d/autojump.bash" >> ${bashrc_file}
-        fi
-        echo "Done!"
+        echo
+        echo "Add the following lines to your ~/.bashrc:"
+        echo
+        echo -e "\tsource ${prefix}/etc/profile.d/autojump.bash"
         echo
         echo "You need to source your ~/.bashrc (source ~/.bashrc) before you can start using autojump."
+        echo
+        echo "To remove autojump, delete the ${prefix} directory and relevant lines from ~/.bashrc."
+        echo
     else
-        echo "Your distribution does not have a $profile_d directory, the default that we install one of the scripts to. Would you like us to copy it into your ~/.bashrc file to make it work? (If you have done this once before, delete the old version before doing it again.) [y/n]"
-        read ans
-        if [ ${#ans} -gt 0 ]; then
-            if [ $ans = "y" -o $ans = "Y" -o $ans = "yes" -o $ans = "Yes" ]; then
-                # Answered yes. Go ahead and add the autojump code
-                echo "" >> ${bashrc_file}
-                echo "#autojump" >> ${bashrc_file}
-                cat autojump.bash | grep -v "^#" >> ${bashrc_file}
-
-                    # Since OSX uses .bash_profile, we need to make sure that .bashrc is properly sourced.
-                    # Makes the assumption that if they have a line: source ~/.bashrc or . ~/.bashrc, that
-                    # .bashrc has been properly sourced and you don't need to add it.
-                    if [ $OS == 'Darwin' -a x`grep -c "^[[:space:]]*\(source\|\.\) ~/\.bashrc[[:space:]]*$" ~/.bash_profile` == x0 ]; then
-                        echo "You are using OSX and your .bash_profile doesn't seem to be sourcing .bashrc"
-                        echo "Adding source ~/.bashrc to your bashrc"
-                        echo -e "\n# Get the aliases and functions" >> ~/.bash_profile
-                        echo -e "if [ -f ${bashrc_file} ]; then\n  . ${bashrc_file}\nfi" >> ~/.bash_profile
-                    fi
-                    echo "You need to source your ~/.bashrc (source ~/.bashrc) before you can start using autojump."
-            else
-                echo "Then you need to put autojump.sh, or the code from it, somewhere where it will get read. Good luck!"
-            fi
-        else
-            echo "Then you need to put autojump.sh, or the code from it, somewhere where it will get read. Good luck!"
-        fi
+        echo "Your distribution does not have a '/etc/profile.d/' directory, please create it manually or use the local install option."
     fi
 else
     mkdir -p ${prefix}/etc/profile.d/
@@ -144,5 +116,5 @@ else
     echo "You need to source your ~/.bashrc (source ~/.bashrc) before you can start using autojump."
     echo
     echo "To remove autojump, delete the ${prefix} directory and relevant lines from ~/.bashrc."
+    echo
 fi
-

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -58,18 +58,26 @@ if [ -d "${prefix}/share/autojump/" ]; then
     sudo rm -v ${prefix}/bin/jumpapplet
     sudo rm -v ${prefix}/bin/autojump
     sudo rm -v ${prefix}/share/man/man1/autojump.1
-    sudo rm -v /etc/profile.d/autojump.zsh
+    sudo rm -v /etc/profile.d/autojump.bash
     sudo rm -v /etc/profile.d/autojump.sh
 
-    echo -e "\nPlease remove the line from ${bashrc_file} :\n"
+    echo
+    echo "Please remove the line from ${bashrc_file} :"
+    echo
     echo -e "\tsource /etc/profile.d/autojump.bash"
+    echo
 fi
 
 # local installations
 if [ -d ~/.autojump/ ]; then
-    echo -e "\nUninstalling from ~/.autojump/ ...\n"
+    echo
+    echo "Uninstalling from ~/.autojump/ ..."
+    echo
     rm -rv ~/.autojump/
 
-    echo -e "\nPlease remove the line from ${bashrc_file} :\n"
+    echo
+    echo "Please remove the line from ${bashrc_file} :"
+    echo
     echo -e "\tsource ~/.autojump/profile.d/autojump.bash"
+    echo
 fi


### PR DESCRIPTION
This mimics install.zsh behavior and solves [issue #50](https://github.com/joelthelion/autojump/issues/50).
- install.sh: installs globally if detected as root
- install.sh --local: installs locally to ~/.autojump/
- uninstall.sh: detects global and/or local install and removes if found
