### PR TITLE
bash: replace missing die function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,8 @@ while true; do
             if [ $# -gt 1 ]; then
                 prefix=$2; shift 2
             else
-                die "--prefix or -p require an argument"
+                echo "--prefix or -p require an argument" 1>&2
+                exit 1
             fi
             ;;
         --)


### PR DESCRIPTION
Removed die function earlier but forgot to replace the functionality.

Did a quick grep and looks like `show_help()` function and relevant calls are still OK.
