### PR TITLE
Add autojump to the end of PROMPT_COMMAND

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -59,7 +59,7 @@ AUTOJUMP='{ [[ "$AUTOJUMP_HOME" == "$HOME" ]] && (autojump -a "$(pwd ${_PWD_ARGS
 
 case $PROMPT_COMMAND in
     *autojump*)    ;;
-    *)   export PROMPT_COMMAND="$AUTOJUMP ; ${PROMPT_COMMAND:-:}";;
+    *)   export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND ; }$AUTOJUMP";;
 esac
 
 function j {


### PR DESCRIPTION
Hi, i use a PROMPT_COMMAND with a function to get the latest exit code like this

``` bash
prompt() {
    # Check exit code
    local exit_code=$?
    if [[ $exit_code -eq 0 ]];then
        # do something
    else
       # do other things
    fi
}

PROMPT_COMMAND="prompt"
```

The problem with the modification of PROMPT_COMMAND by autojump.bash is that it add himself at the start of the PROMPT_COMMAND variable and so the exit code in my function is always 0. It will better if autojump will add himself at the end of the PROMPT_COMMAND variable to avoid this issue.

In attachment the patch to fix this issue
