### PR TITLE
set permission 0755 to _j in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,7 @@ if [ ! ${local} ]; then
         success=
         fpath=`/usr/bin/env zsh -c 'echo $fpath'`
         for f in ${fpath}; do
-            cp -v ./bin/_j ${f} && success=true && break
+            install -v -m 0755 ./bin/_j ${f} && success=true && break
         done
 
         if [ ! ${success} ]; then
@@ -197,7 +197,7 @@ else # local installation
 
     if [ ${shell} == "zsh" ]; then
         mkdir -p ${prefix}/functions/
-        cp ./bin/_j ${prefix}/functions/
+        install -v -m 0755 ./bin/_j ${prefix}/functions/
     fi
 
     add_msg "local" ${shell}


### PR DESCRIPTION
In my Ubuntu environment, I didn't have permission to execute of _j after call install.sh. So I modified install.sh to set permission 0755 by "install" instead of "cp".
