### PR TITLE
Fix install.sh script to support destdir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,59 +1,80 @@
 #!/usr/bin/env bash
 
-function add_msg {
-    echo
-    echo "Please add the line to ~/.${2}rc :"
-    echo
-
-    if [ "${1}" == "global" ]; then
-        echo -e "\t[[ -s /etc/profile.d/autojump.${2} ]] && source /etc/profile.d/autojump.${2}"
-    elif [ "${1}" == "local" ]; then
-        echo -e "\t[[ -s ~/.autojump/etc/profile.d/autojump.${2} ]] && source ~/.autojump/etc/profile.d/autojump.${2}"
-    fi
-
-    echo
-    echo "You need to run 'source ~/.${2}rc' before you can start using autojump."
-    echo
-    echo "To remove autojump, run './uninstall.sh'"
-    echo
-}
-
 function help_msg {
+    echo "./install.sh [OPTION..]"
     echo
-    echo "./install.sh [--global or --local] [--bash or --zsh] [--prefix /usr/] "
+    echo " -a, --auto           Try to determine destdir, prefix, shell (and zshshare if apply)"
+    echo " -g, --global         Use default global settings (destdir=/; prefix=usr)"
+    echo " -l, --local          Use default local settings (destdir=~/.autojump)"
     echo
-    echo "If run without any arguments, the installer will:"
+    echo " -d, --destdir PATH   Set install destination to PATH"
+    echo " -p, --prefix PATH    Use PATH as prefix"
+    echo " -Z, --zshshare PATH  Use PATH as zsh share destination"
     echo
-    echo -e "\t- as root install globally into /usr/"
-    echo -e "\t- as non-root install locally to ~/.autojump/"
-    echo -e "\t- version will be based on \$SHELL environmental variable"
+    echo " -b, --bash           Install for bash only"
+    echo " -z, --zsh            Install for zsh only"
+    echo " (If neither are specified, both bash & zsh support are installed)"
     echo
+    echo " -f, --force          Ignore python version check"
+    echo " -P, --show_path      Only show installation paths, don't install anything"
+    echo
+    echo "Will install autojump into:"
+    echo ' Binaries:        $destdir$prefix/bin'
+    echo ' Documentation:   $destdir$prefix/share/man/man1'
+    echo ' Icon:            $destdir$prefix/share/autojump'
+    echo ' Shell scripts:   $destdir/etc/profile.d'
+    echo ' zsh functions:   $destdir$zshsharedir'
+    echo
+    echo 'Unless specified, $zshshare will be :'
+    echo ' - First writable directory in $fpath when --auto was used'
+    echo ' - $destdir$prefix/functions if --local was used'
+    echo ' - $destdir$prefix/share/zsh/site-functions'
 }
 
-# Default install directory.
-shell=`echo ${SHELL} | awk -F/ '{ print $NF }'`
+show_path=
+auto=
+local=
 force=
-if [[ ${UID} -eq 0 ]]; then
-    local=
-    prefix=/usr
-else
-    local=true
-    prefix=~/.autojump
-fi
+shell=
+destdir=
+prefix="usr/local"
+zshsharedir=
 
 # Command line parsing
 while true; do
     case "$1" in
+        -a|--auto)
+            auto=true
+            force=
+            shell=`echo ${SHELL} | awk -F/ '{ print $NF }'`
+            if [[ ${UID} -eq 0 ]]; then
+                destdir=
+                prefix=usr
+            else
+                destdir=~/.autojump
+                prefix=
+            fi
+            zshsharedir=
+            shift
+            ;;
         -b|--bash)
             shell="bash"
             shift
+            ;;
+        -d|--destdir)
+            if [ $# -gt 1 ]; then
+                destdir=$2; shift 2
+            else
+                echo "--destdir or -d requires an argument" 1>&2
+            fi
             ;;
         -f|--force)
             force=true
             shift
             ;;
         -g|--global)
-            local=
+            destdir=
+            prefix=usr
             shift
             ;;
         -h|--help|-\?)
@@ -62,7 +83,12 @@ while true; do
             ;;
         -l|--local)
             local=true
-            prefix=~/.autojump
+            destdir=~/.autojump
+            prefix=
+            shift
+            ;;
+        -P|--show_paths)
+            show_path=true
             shift
             ;;
         -p|--prefix)
@@ -76,6 +102,14 @@ while true; do
         -z|--zsh)
             shell="zsh"
             shift
+            ;;
+        -Z|--zshshare)
+            if [ $# -gt 1 ]; then
+                zshsharedir=$2; shift 2
+            else
+                echo "--zshshare or -Z requires an argument" 1>&2
+                exit 1
+            fi
             ;;
         --)
             shift
@@ -92,18 +126,62 @@ while true; do
     esac
 done
 
-# check for valid local install options
-if [[ ${UID} != 0 ]] && [ ! ${local} ]; then
-    echo
-    echo "Please rerun as root or use the --local option."
-    echo
-    exit 1
+# destdir must be a full path, and end with a slash
+if [[ -n ${destdir} ]]; then
+    if [[ ${destdir:0:1} != "/" ]]; then
+        echo "Error: destdir must be a full path" 1>&2
+        exit 1
+    fi
+    len=${#destdir}
+    if [[ ${destdir:len - 1} != "/" ]]; then
+        destdir="$destdir/"
+    fi
+else
+    destdir="/"
+fi
+
+# prefix should not start with, and end with, a slash
+if [[ -n ${prefix} ]]; then
+    if [[ ${prefix:0:1} == "/" ]]; then
+        prefix=${prefix:1}
+    fi
+    len=${#prefix}
+    if [[ ${prefix:len - 1} != "/" ]]; then
+        prefix="$prefix/"
+    fi
 fi
 
 # check shell if supported
-if [[ ${shell} != "bash" ]] && [[ ${shell} != "zsh" ]]; then
+if [[ -n ${shell} ]] && [[ ${shell} != "bash" ]] && [[ ${shell} != "zsh" ]]; then
     echo "Unsupported shell (${shell}). Use --bash or --zsh to explicitly define shell."
     exit 1
+fi
+
+# zsh functions
+if [[ -z $shell ]] || [[ $shell == "zsh" ]]; then
+    if [[ $auto ]]; then
+        # look for writable dir in fpath
+        success=
+        fpath=`/usr/bin/env zsh -c 'echo $fpath'`
+        for f in ${fpath}; do
+            if [[ -d $f ]] && [[ -w $f ]]; then
+                zshsharedir=${f:1}
+                success=true
+                break
+            fi
+        done
+        if [[ ! $success ]]; then
+            echo "Error: failed to determine zsh functions dir" 1>&2
+            exit 1
+        fi
+    elif [[ -z $zshsharedir ]]; then
+        # if not set, use a default
+        if [[ $local ]]; then
+            zshsharedir="${prefix}functions"
+        else
+            zshsharedir="${prefix}share/zsh/site-functions"
+        fi
+    fi
 fi
 
 # check Python version
@@ -125,53 +203,51 @@ if [ ! ${force} ]; then
 fi
 
 echo
-echo "Installing ${shell} version of autojump to ${prefix} ..."
+echo "Installating autojump..."
+echo
+echo "Destination:      $destdir"
+if [[ -n $prefix ]]; then
+    echo "Prefix:           /$prefix"
+fi
+if [[ -n $shell ]]; then
+    echo "Shell:            $shell"
+else
+    echo "Shell:            bash & zsh"
+fi
+echo
+echo "Binary:           ${destdir}${prefix}bin/"
+echo "Documentation:    ${destdir}${prefix}share/man/man1/"
+echo "Icon:             ${destdir}${prefix}share/autojump/"
+echo "Shell scripts:    ${destdir}etc/profile.d/"
+if [[ -z $shell ]] || [[ $shell == "zsh" ]]; then
+    echo "zsh functions:    ${destdir}${zshsharedir}"
+fi
 echo
 
-# INSTALL AUTOJUMP
-mkdir -p ${prefix}/share/autojump/
-mkdir -p ${prefix}/bin/
-mkdir -p ${prefix}/share/man/man1/
-cp -v ./bin/icon.png ${prefix}/share/autojump/
-cp -v ./bin/jumpapplet ${prefix}/bin/
-cp -v ./bin/autojump ${prefix}/bin/
-cp -v ./bin/autojump_argparse.py ${prefix}/bin/
-cp -v ./docs/autojump.1 ${prefix}/share/man/man1/
-
-# global installation
-if [ ! ${local} ]; then
-    # install _j to the first accessible directory
-    if [ ${shell} == "zsh" ]; then
-        success=
-        fpath=`/usr/bin/env zsh -c 'echo $fpath'`
-        for f in ${fpath}; do
-            install -v -m 0755 ./bin/_j ${f} && success=true && break
-        done
-
-        if [ ! ${success} ]; then
-            echo
-            echo "Couldn't find a place to put the autocompletion file, please copy _j into your \$fpath"
-            echo "Installing the rest of autojump ..."
-            echo
-        fi
-    fi
-
-    if [ -d "/etc/profile.d" ]; then
-        cp -v ./bin/autojump.sh /etc/profile.d/
-        cp -v ./bin/autojump.${shell} /etc/profile.d/
-        add_msg "global" ${shell}
-    else
-        echo "Your distribution does not have a '/etc/profile.d/' directory, please create it manually or use the local install option."
-    fi
-else # local installation
-    mkdir -p ${prefix}/etc/profile.d/
-    cp -v ./bin/autojump.sh ${prefix}/etc/profile.d/
-    cp -v ./bin/autojump.${shell} ${prefix}/etc/profile.d/
-
-    if [ ${shell} == "zsh" ]; then
-        mkdir -p ${prefix}/functions/
-        install -v -m 0755 ./bin/_j ${prefix}/functions/
-    fi
-
-    add_msg "local" ${shell}
+if [[ $show_path ]]; then
+    echo "--show_path (-P) used, stopping"
+    exit
 fi
+
+# INSTALL AUTOJUMP
+mkdir -p ${destdir}${prefix}share/autojump/
+mkdir -p ${destdir}${prefix}bin/
+mkdir -p ${destdir}${prefix}share/man/man1/
+cp -v ./bin/icon.png ${destdir}${prefix}share/autojump/
+cp -v ./bin/jumpapplet ${destdir}${prefix}bin/
+cp -v ./bin/autojump ${destdir}${prefix}bin/
+cp -v ./bin/autojump_argparse.py ${destdir}${prefix}bin/
+cp -v ./docs/autojump.1 ${destdir}${prefix}share/man/man1/
+mkdir -p ${destdir}etc/profile.d/
+cp -v ./bin/autojump.sh ${destdir}etc/profile.d/
+if [[ -z $shell ]] || [[ $shell == "bash" ]]; then
+    cp -v ./bin/autojump.bash ${destdir}etc/profile.d/
+fi
+if [[ -z $shell ]] || [[ $shell == "zsh" ]]; then
+    cp -v ./bin/autojump.zsh ${destdir}etc/profile.d/
+    mkdir -p ${destdir}${zshsharedir}
+    install -v -m 0755 ./bin/_j ${destdir}${zshsharedir}
+fi
+
+echo "Remember: you need to source ${destdir}etc/profile.d/autojump.sh before you can use autojump"
+


### PR DESCRIPTION
The install script didn't support the use of a destination directory, which can
be pretty useful e.g. to create packages.
## 

This adds a few options, but should work pretty much as it dir before, only allowing to set a destination directory as well. Lacking this made the script unable to be used to create packages, e.g. see https://bugs.archlinux.org/task/32669

The --auto mimics the original behavior (without parameters), and --local or --global should be enough most of the times.
