### PR TITLE
Fix --dry-run not defaulting to --auto

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,11 @@ if [[ ${#} == 0 ]]; then
     set -- "--auto"
 fi
 
+# Only dry-run should also default to --auto
+if [[ ${#} == 1 ]] && ([[ $1 = "-n" ]] || [[ $1 = "--dry-run" ]]); then
+    set -- "-n" "--auto"
+fi
+
 # Command line parsing
 while true; do
     case "$1" in


### PR DESCRIPTION
Using --dry-run alone wouldn't default to --auto and therefore show different
paths that what would actually be used upon installation.
