### PR TITLE
Avoid calls to stat() in find_matches

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -355,14 +355,21 @@ def find_matches(db, patterns, max_matches=1, ignore_case=False, fuzzy=False):
                 end = d[0].split('/')[-1]
 
             # collisions: ignore lower weight paths
-            if end not in end_dirs and (os.path.exists(d[0]) or TESTING):
-                # avoid jumping to current directory
-                if current_dir == os.path.realpath(d[0]):
-                    continue
+            if end not in end_dirs:
                 end_dirs[end] = d[0]
 
         # find the first match (heighest weight)
-        found = get_close_matches(patterns[-1], end_dirs, 1, .6)
+        while True:
+            found = get_close_matches(patterns[-1], end_dirs, n=1, cutoff=.6)
+            if not found:
+                break
+            # avoid jumping to current directory
+            if (os.path.exists(found[0]) or TESTING) and \
+                current_dir != os.path.realpath(found[0]):
+                break
+            # continue with the last found directory removed
+            del end_dirs[found[0]]
+
         if found:
             found = found[0]
             results.append(end_dirs[found])


### PR DESCRIPTION
Instead of stating every directory to check if its realpath is the
current directory, only do so for any potential matches.
