### PR TITLE
Use named args when calling find_matches

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -424,15 +424,16 @@ def shell_utility():
 
     results = []
     if not ALWAYS_IGNORE_CASE:
-        results = find_matches(db, patterns, max_matches, False)
+        results = find_matches(db, patterns, max_matches, ignore_case=False)
 
     # if no results, try ignoring case
     if ARGS.complete or not results:
-        results = find_matches(db, patterns, max_matches, True)
+        results = find_matches(db, patterns, max_matches, ignore_case=True)
 
     # if no results, try approximate matching
     if not results:
-        results = find_matches(db, patterns, max_matches, True, True)
+        results = find_matches(db, patterns, max_matches, ignore_case=True,
+                fuzzy=True)
 
     quotes = ""
     if ARGS.complete and ARGS.bash: quotes = "'"


### PR DESCRIPTION
This should make it clearer at first glance where True and False is
referring to.
