### PR TITLE
Use autojump to open a directory with a file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Grab a copy of autojump:
 Run the installation script:
 
     cd autojump
-    ./install.sh [ --local ]
+    ./install.sh [ --local ] [ --zsh ]
 
 and follow on screen instructions.
 
@@ -192,6 +192,21 @@ ADDITIONAL CONFIGURATION
         export AUTOJUMP_AUTOCOMPLETE_CMDS='cp vim'
 
     Changes require reloading autojump to take into effect.
+
+-   Use a File Manager to Open Jumped-to Directories
+
+    You can modify your \~/.bashrc or \~/.zsh to make autojump open a
+    directory for you. Add the following lines in your \~/.bashrc or
+    \~/.zshrc:
+
+        function jo { xdg-open $(autojump $@); }
+        complete -F _autojump jo
+
+    If you're using Mac OS X, you can replace `xdg-open` with `open`.
+
+    After executing `source ~/.bashrc` or `source ~/.zshrc`, you can try
+    `jo foo`, which behaves like `j foo` except that it opens the `foo`
+    directory with a file manager.
 
 ADVANCED USAGE
 --------------

--- a/docs/autojump.1
+++ b/docs/autojump.1
@@ -140,6 +140,28 @@ export\ AUTOJUMP_AUTOCOMPLETE_CMDS=\[aq]cp\ vim\[aq]
 .PP
 Changes require reloading autojump to take into effect.
 .RE
+.IP \[bu] 2
+Use a File Manager to Open Jumped-to Directories
+.RS 2
+.PP
+You can modify your ~/.bashrc or ~/.zsh to make autojump open a
+directory for you.
+Add the following lines in your ~/.bashrc or ~/.zshrc:
+.IP
+.nf
+\f[C]
+function\ jo\ {\ xdg-open\ $(autojump\ $\@);\ }
+complete\ -F\ _autojump\ jo
+\f[]
+.fi
+.PP
+If you\[aq]re using Mac OS X, you can replace \f[C]xdg-open\f[] with
+\f[C]open\f[].
+.PP
+After executing \f[C]source\ ~/.bashrc\f[] or \f[C]source\ ~/.zshrc\f[],
+you can try \f[C]jo\ foo\f[], which behaves like \f[C]j\ foo\f[] except
+that it opens the \f[C]foo\f[] directory with a file manager.
+.RE
 .SS ADVANCED USAGE
 .IP \[bu] 2
 Using Multiple Arguments

--- a/docs/body.md
+++ b/docs/body.md
@@ -61,6 +61,17 @@ Options must be passed to 'autojump' and not the 'j' wrapper function.
 
     Changes require reloading autojump to take into effect.
 
+- Use a File Manager to Open Jumped-to Directories
+
+    You can modify your ~/.bashrc or ~/.zsh to make autojump open a directory for you. Add the following lines in your ~/.bashrc or ~/.zshrc:
+
+        function jo { xdg-open $(autojump $@); }
+        complete -F _autojump jo
+
+    If you're using Mac OS X, you can replace `xdg-open` with `open`.
+
+    After executing `source ~/.bashrc` or `source ~/.zshrc`, you can try `jo foo`, which behaves like `j foo` except that it opens the `foo` directory with a file manager.
+
 ## ADVANCED USAGE
 
 - Using Multiple Arguments


### PR DESCRIPTION
I got tired of opening a file manager and drilling down several levels of subdirectories to reach the directory I want. I thought it would be nice to have autojump open a directory for me.

I added commands `jo` and `jco` for this purpose. Descriptions for these commands have also been written to docs.
