### PR TITLE
Handle autojump errors when opening file manager

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -98,20 +98,26 @@ function jc {
 }
 
 function jo {
-    case ${OSTYPE} in
-        linux-gnu)
-            xdg-open "$(autojump $@)"
-            ;;
-        darwin*)
-            open "$(autojump $@)"
-            ;;
-        cygwin)
-            cmd /C start "" $(cygpath -w -a $(pwd))
-            ;;
-        *)
-            echo "Unknown operating system." 1>&2
-            ;;
-    esac
+    if [ -z $(autojump $@) ]; then
+        echo "autojump: directory '${@}' not found"
+        echo "Try \`autojump --help\` for more information."
+        false
+    else
+        case ${OSTYPE} in
+            linux-gnu)
+                xdg-open "$(autojump $@)"
+                ;;
+            darwin*)
+                open "$(autojump $@)"
+                ;;
+            cygwin)
+                cmd /C start "" $(cygpath -w -a $(pwd))
+                ;;
+            *)
+                echo "Unknown operating system." 1>&2
+                ;;
+        esac
+    fi
 }
 
 function jco {

--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -62,20 +62,26 @@ function jc {
 }
 
 function jo {
-    case ${OSTYPE} in
-        linux-gnu)
-            xdg-open "$(autojump $@)"
-            ;;
-        darwin*)
-            open "$(autojump $@)"
-            ;;
-        cygwin)
-            cmd /C start "" $(cygpath -w -a $(pwd))
-            ;;
-        *)
-            echo "Unknown operating system." 1>&2
-            ;;
-    esac
+    if [ -z $(autojump $@) ]; then
+        echo "autojump: directory '${@}' not found"
+        echo "Try \`autojump --help\` for more information."
+        false
+    else
+        case ${OSTYPE} in
+            linux-gnu)
+                xdg-open "$(autojump $@)"
+                ;;
+            darwin*)
+                open "$(autojump $@)"
+                ;;
+            cygwin)
+                cmd /C start "" $(cygpath -w -a $(pwd))
+                ;;
+            *)
+                echo "Unknown operating system." 1>&2
+                ;;
+        esac
+    fi
 }
 
 function jco {


### PR DESCRIPTION
Trying to fix Issue #177. If a `autojump "search terms"` fails, print the autojump error output and do not execute `xdg-open`.
