### PR TITLE
normalize path ending before adding to the DB

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -89,6 +89,7 @@ class Database:
         """
         Increase weight of existing paths or initialize new ones to 10.
         """
+        path = path.rstrip(os.sep)
         if path not in self.data:
             self.data[path] = increment
         else:


### PR DESCRIPTION
Path endings should be normalized before being added to the database as the matching algorithm depends on exact matches of path endings.

I had something like this in my DB:

```
10  /projects/a/b/code
100 /data/code/
```

"j code" jumped to "/projects/a/b/code" instead of "/data/code/".
