### PR TITLE
try to use absolute paths when manually adding

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -272,7 +272,11 @@ def options():
     if (ARGS.add):
         if(ARGS.add != os.path.expanduser("~")):
             db = Database(DB_FILE)
-            db.add(decode(ARGS.add))
+            path = decode(ARGS.add)
+            if os.path.exists(path):
+                db.add(os.path.abspath(path))
+            else:
+                db.add(path)
         return True
 
     if (ARGS.decrease):


### PR DESCRIPTION
This patch changes the "--add" command to act more like manual "cd" commands.

When an existent relative path is given, the absolute path gets added to the database - relative paths would be removed anyway the next time "--purge" is called.

(This might be useful if one tries to import a whole cd-command history based on a root path - I did this based on my home directory)
