### PR TITLE
Disable export of PROMPT_COMMAND in bash-completion

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -68,7 +68,7 @@ case $PROMPT_COMMAND in
     *autojump*)
         ;;
     *)
-        export PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }autojump_add_to_database"
+        PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }autojump_add_to_database"
         ;;
 esac
 


### PR DESCRIPTION
exporting the prompt seems to be too harsh and breaks the shell in Emacs as the PROMPT_COMMAND for xterm (say) overwrites the 'dumb' PROMPT_COMMAND, which now is 'contaminated' with ASCII escape strings.

I have not detected any side effects of this. . . 
