### PR TITLE
fixed typo

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -193,7 +193,7 @@ class Database:
             for path, weight in sorted(self.data.items(),
                     key=itemgetter(1),
                     reverse=True):
-                temp.write((unico("%s\t%s\n")%(weight, path)).encode("utf-8"))
+                temp.write((unico("%s\t%s\n" % (weight, path)).encode("utf-8")))
 
             # catching disk errors and skipping save when file handle can't
             # be closed.


### PR DESCRIPTION
The previous code was most probably a typo if i think. encoding ["%s\t%s\n"] and then substituting the values is not probably what you intended to do here.
