### PR TITLE
Use non-lazy enumeration for removal of dictionary keys.

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -173,7 +173,7 @@ class Database:
         Deletes all entries that no longer exist on system.
         """
         removed = []
-        for path in self.data.keys():
+        for path in list(self.data.keys()):
             if not os.path.exists(path):
                 removed.append(path)
                 del self.data[path]


### PR DESCRIPTION
In the current situation, iterating over `self.data.keys()` is OK only when
the dictionary is not modified, as `self.data.keys()` is lazily generated,
at least in Python 3.

Unfortunately, as we intend to change the dictionary with the `--purge`
option, we get a runtime exception when iterating the loop.

This commit fixes it by making the generation of the list of keys occur only
once, so that the dictionary itself can be modified in the body of the loop.

Tested with both Python 2.7 and Python 3.3.

Signed-off-by: Rogério Brito rbrito@ime.usp.br
