### PR TITLE
Added Fish support

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -13,7 +13,7 @@ end
 
 # local installation
 if test -d ~/.autojump
-    export PATH ~/.autojump/bin $PATH
+    set -x PATH ~/.autojump/bin $PATH
 end
 
 set -x AUTOJUMP_HOME $HOME


### PR DESCRIPTION
A few differences from Bash version:
1. No `AUTOJUMP_KEEP_SYMLINKS`. Fish always resolves them (for both `pwd` and `cd`).
2. No support for file name completion for 3rd party programs. Fish doesn't seem to like when prefix changes in progressive completion requests, so `f__1__/foo/bar` will not complete to `'/foo/bar'`.

This is just a shell wrapper, I did not touch installation scripts as you seem to be actively working on them. Let me know if you need it added. There are a few differences, so install/uninistall messages need changing (source command, init file path).
