### PR TITLE
Enable autojump only when running in interactive mode

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -65,7 +65,9 @@ case $PROMPT_COMMAND in
     *autojump*)
         ;;
     *)
-        PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }autojump_add_to_database"
+        if [ -n "$PS1" ]; then
+                PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }autojump_add_to_database"
+        fi
         ;;
 esac
 

--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -29,8 +29,10 @@ function autojump_chpwd() {
     { (autojump -a "$(pwd ${_PWD_ARGS})"&)>/dev/null 2>>|${AUTOJUMP_DATA_DIR}/autojump_errors ; } 2>/dev/null
 }
 
-typeset -ga chpwd_functions
-chpwd_functions+=autojump_chpwd
+if [ -n "$PS1" ]; then
+	typeset -ga chpwd_functions
+	chpwd_functions+=autojump_chpwd
+fi
 
 function j {
     # Cannot use =~ due to MacPorts zsh v4.2, see issue #125.


### PR DESCRIPTION
Having autojump enabled when executing scripts will pollute the jump history with unwanted directories. This simply checks for an interactive session and enable autojump only in this case.
