### PR TITLE
wrong command in synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Jump to a previously visited subdirectory of the current directory:
 
 Show database entries and their respective key weights:
 
-    j --stat
+    autojump --stat
 
 DESCRIPTION
 -----------


### PR DESCRIPTION
as stated below in the readme, the --stats parameter needs to be passed to `autojump` and not its wrapper `j`. I tested with the apt-get-able version of autojump and indeed it does not work with `j`. 
