### PR TITLE
bash: call autojump -a only if CWD changed

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -57,7 +57,11 @@ fi
 
 autojump_add_to_database() {
     if [[ "${AUTOJUMP_HOME}" == "${HOME}" ]]; then
-        autojump -a "$(pwd ${_PWD_ARGS})" 1>/dev/null 2>>"${AUTOJUMP_DATA_DIR}/autojump_errors"
+        AUTOJUMP_CWD="$(pwd ${_PWD_ARGS})"
+        if [[ "$AUTOJUMP_CWD" != "$AUTOJUMP_LASTWD" ]]; then
+            autojump -a "$AUTOJUMP_CWD" 1>/dev/null 2>>"${AUTOJUMP_DATA_DIR}/autojump_errors"
+            AUTOJUMP_LASTWD="$AUTOJUMP_CWD"
+        fi
     fi
 }
 


### PR DESCRIPTION
With this patch the 'autojump -a' command is only called if the CWD changed in bash.

Now hold the 'enter' key at a bash prompt, and see that the console doesn't lag anymore.
