### PR TITLE
Fix escaping issues in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ KNOWN ISSUES
 ------------
 
 -   For bash users, autojump keeps track of directories as a pre-command
-    hook by modifying $PROMPT_COMMAND. If you overwrite $PROMPT\_COMMAND
-    in \~/.bashrc you can cause problems. Don't do this:
+    hook by modifying \$PROMPT\_COMMAND. If you overwrite
+    \$PROMPT\_COMMAND in \~/.bashrc you can cause problems. Don't do
+    this:
 
         export PROMPT_COMMAND="history -a"
 
@@ -242,7 +243,7 @@ FILES
 
 If installed locally, autojump is self-contained in *\~/.autojump/*.
 
-The database is stored in *\$XDG*DATA\_HOME/autojump/autojump.txt\_.
+The database is stored in *\$XDG\_DATA\_HOME/autojump/autojump.txt*.
 
 REPORTING BUGS
 --------------

--- a/docs/autojump.1
+++ b/docs/autojump.1
@@ -191,9 +191,8 @@ Changes require reloading autojump to take into effect.
 .SS KNOWN ISSUES
 .IP \[bu] 2
 For bash users, autojump keeps track of directories as a pre\-command
-hook by modifying
-\f[I]P\f[]\f[I]R\f[]\f[I]O\f[]\f[I]M\f[]\f[I]P\f[]\f[I]T\f[]~\f[I]C\f[]~\f[I]O\f[]\f[I]M\f[]\f[I]M\f[]\f[I]A\f[]\f[I]N\f[]\f[I]D\f[]. \f[I]I\f[]\f[I]f\f[]\f[I]y\f[]\f[I]o\f[]\f[I]u\f[]\f[I]o\f[]\f[I]v\f[]\f[I]e\f[]\f[I]r\f[]\f[I]w\f[]\f[I]r\f[]\f[I]i\f[]\f[I]t\f[]\f[I]e\f[]PROMPT_COMMAND
-in ~/.bashrc you can cause problems.
+hook by modifying $PROMPT_COMMAND.
+If you overwrite $PROMPT_COMMAND in ~/.bashrc you can cause problems.
 Don\[aq]t do this:
 .RS 2
 .IP
@@ -221,7 +220,7 @@ If you want to jump a directory called \f[C]\-\-music\f[], try using
 If installed locally, autojump is self\-contained in
 \f[I]~/.autojump/\f[].
 .PP
-The database is stored in \f[I]$XDG\f[]DATA_HOME/autojump/autojump.txt_.
+The database is stored in \f[I]$XDG_DATA_HOME/autojump/autojump.txt\f[].
 .SS REPORTING BUGS
 .PP
 For any usage related issues or feature requests please visit:

--- a/docs/body.md
+++ b/docs/body.md
@@ -96,7 +96,7 @@ ADDITIONAL CONFIGURATION
 ## KNOWN ISSUES
 
 - For bash users, autojump keeps track of directories as a pre-command hook by
-  modifying $PROMPT_COMMAND. If you overwrite $PROMPT_COMMAND in ~/.bashrc you
+  modifying \$PROMPT\_COMMAND. If you overwrite \$PROMPT\_COMMAND in ~/.bashrc you
   can cause problems. Don't do this:
 
         export PROMPT_COMMAND="history -a"
@@ -113,7 +113,7 @@ ADDITIONAL CONFIGURATION
 
 If installed locally, autojump is self-contained in _~/.autojump/_.
 
-The database is stored in _$XDG_DATA_HOME/autojump/autojump.txt_.
+The database is stored in _$XDG\_DATA\_HOME/autojump/autojump.txt_.
 
 ## REPORTING BUGS
 


### PR DESCRIPTION
Pandoc treats both underscores and dollar signs as non-literal
characters which screwed up the manpage.

This is not really ready to be merged because GitHubs markdown does not treat dollar signs as some form of special character, so at least README.md now looks weird on GitHub but the manpage looks good. I'm not sure which one is more important.
