### PR TITLE
./install.py and ./uninstall.py are not executable on fresh git pull.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ TAGNAME = release-v$(VERSION)
 .PHONY: docs install uninstall lint tar test
 
 install:
-	install.py
+	python install.py
 
 uninstall:
-	uninstall.py
+	python uninstall.py
 
 docs:
 	pandoc -s -w man docs/manpage_header.md docs/header.md docs/body.md -o docs/autojump.1


### PR DESCRIPTION
These scripts are not executable on a fresh git pull.  So use python explicitly.
