### PR TITLE
bin/autojump.zsh: only add existing dirs

### DIFF
--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -1,7 +1,9 @@
 # set user installation paths
-if [[ -d ~/.autojump ]]; then
+if [[ -d ~/.autojump/bin ]]; then
     path=(~/.autojump/bin ${path})
-    fpath=(~/.autojump/functions/ ${fpath})
+fi
+if [[ -d ~/.autojump/functions ]]; then
+    fpath=(~/.autojump/functions ${fpath})
 fi
 
 


### PR DESCRIPTION
With a custom install method (e.g. checkout in ~/.autojump), ~/.autojump/functions will not be present.
