### PR TITLE
Completion and jumping for empty needles

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -193,9 +193,6 @@ def find_matches(entries, needles, check_entries=True):
 
 
 def handle_tab_completion(needle, entries):
-    if not needle:
-        sys.exit(0)
-
     tab_needle, tab_index, tab_path = get_tab_entry_info(needle, TAB_SEPARATOR)
 
     if tab_path:
@@ -364,7 +361,7 @@ def main(args):  # noqa
         save(config, first(add_path(load(config), args.add)))
     elif args.complete:
         handle_tab_completion(
-                needle=first(sanitize(args.directory)),
+                needle=first(chain(sanitize(args.directory), [''])),
                 entries=entriefy(load(config)))
     elif args.decrease:
         data, entry = decrease_path(load(config), get_pwd(), args.decrease)
@@ -382,8 +379,12 @@ def main(args):  # noqa
     elif args.stat:
         print_stats(load(config), config['data_path'])
     elif not args.directory:
-        # always return a path to calling shell functions
-        print_local('.')
+        # Return best match.
+        entries = entriefy(load(config))
+        print_local(first(chain(
+                imap(attrgetter('path'), find_matches(entries, [''])),
+                # always return a path to calling shell functions
+                ['.'])))
     else:
         entries = entriefy(load(config))
         needles = sanitize(args.directory)


### PR DESCRIPTION
This adds support for `j <tab>` and `j` without a needle to jump to the
first/best match.

Fixes https://github.com/joelthelion/autojump/issues/269
