### PR TITLE
Fix bad encoding

### DIFF
--- a/bin/autojump_utils.py
+++ b/bin/autojump_utils.py
@@ -30,6 +30,8 @@ def create_dir(path):
 
 def encode_local(string):
     """Converts string into user's preferred encoding."""
+    if is_python3():
+        return string
     return string.encode(sys.getfilesystemencoding() or 'utf-8')
 
 


### PR DESCRIPTION
In python3, `string.encode` returns a byte array like: `b'14.1:\t/home/felix/devel/autojump'`

This stops autojump from functioning at all.
