### PR TITLE
bash: fixes slow prompt and not add dir upon return key

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -45,7 +45,7 @@ case $PROMPT_COMMAND in
     *autojump*)
         ;;
     *)
-        PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }autojump_add_to_database"
+        PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }[[ $OLDPWD == $PPWD ]] && autojump_add_to_database && PPWD=$PWD"
         ;;
 esac
 

--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -45,7 +45,7 @@ case $PROMPT_COMMAND in
     *autojump*)
         ;;
     *)
-        PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }[[ $OLDPWD == $PPWD ]] && autojump_add_to_database && PPWD=$PWD"
+        PROMPT_COMMAND="${PROMPT_COMMAND:+$(echo "${PROMPT_COMMAND}" | awk '{gsub(/; *$/,"")}1') ; }[[ \$OLDPWD == \$PPWD ]] && autojump_add_to_database && PPWD=\$PWD"
         ;;
 esac
 


### PR DESCRIPTION
This fixes (#303) slow prompt issue, because every time one hits return
key, autojump_add_to_database python code is executed, which is very
noticeably slow.

Also autojump should not add current directory to a database if it has
not changed since last time return key was pressed, so this fixes that
as well.
