### PR TITLE
Close the temporary file before re-opening it.

### DIFF
--- a/bin/autojump_data.py
+++ b/bin/autojump_data.py
@@ -121,6 +121,8 @@ def save(config, data):
     try:
         # write to temp file
         temp = NamedTemporaryFile(delete=False)
+        # prevent Windows errors by closing the file before opening it.
+        temp.close()
 
         with open(temp.name, 'w', encoding='utf-8', errors='replace') as f:
             for path, weight in data.items():


### PR DESCRIPTION
On Windows, we cannot reuse the temp.name to
reopen the file _unless_ it has been closed
before [0].

This problem in turn made the `move_file`
request to fail, since the file was still
open at the time.

[0] https://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile
