### PR TITLE
Disable echo of command check

### DIFF
--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -8,7 +8,7 @@ fi
 
 
 # set homebrew installation paths
-if command -v brew && [[ -d "$(brew --prefix)/share/zsh/site-functions" ]]; then
+if command -v brew > /dev/null 2>&1 && [[ -d "$(brew --prefix)/share/zsh/site-functions" ]]; then
     fpath=("$(brew --prefix)/share/zsh/site-functions" ${fpath})
 fi
 


### PR DESCRIPTION
For some reason, "command -v brew" by itself has started to output "/usr/local/bin/brew" whenever I start a new shell (in iTerm2 2.0 on OS X 10.9.4 with zsh, oh-my-zsh etc). This fixes it, and it looks like it's the recommended way anyway:
- http://unix.stackexchange.com/a/85250/4678
- http://www.cyberciti.biz/faq/unix-linux-shell-find-out-posixcommand-exists-or-not/
