### PR TITLE
Fix no jump when query begins with - in Zsh

### DIFF
--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -42,7 +42,7 @@ chpwd_functions+=autojump_chpwd
 
 # default autojump command
 j() {
-    if [[ ${@} == -* ]]; then
+    if [[ ${@} == -* && ! (${#} -eq 2 && ${1} == '--') ]]; then
         autojump ${@}
         return
     fi


### PR DESCRIPTION
Without this commit, the following command prints the
path found by autojump, but doesn't actually jump because
the Zsh script assumes we're passing an option to j():

```
j -- -tools
```

The -- is needed; otherwise `-tools` would be interpreted as
a (bad) autojump option.

The Bash version (and probably others) does the same, but
this commit only fixes it for Zsh.
