### PR TITLE
Working test for Darwin

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -11,7 +11,7 @@ complete -x -c j -a '(autojump --complete (commandline -t))'
 
 
 # set error file location
-if (uname) == "Darwin"
+if test (uname) = "Darwin"
     set -x AUTOJUMP_ERROR_PATH ~/Library/autojump/errors.log
 else if test -d $XDG_DATA_HOME
     set -x AUTOJUMP_ERROR_PATH $XDG_DATA_HOME/autojump/errors.log


### PR DESCRIPTION
In fish 2.1.0, at least, the existing check doesn't work - fish errors about (uname) not being a known command.

(I'm also having problems with the set -x for the ERROR_PATH - I'm not sure what happens there: the test -d triggers, but $XDG_DATA_HOME echos "")
