### PR TITLE
Fix "modify_autojump_sh" wrong behavior

### DIFF
--- a/install.py
+++ b/install.py
@@ -29,13 +29,13 @@ def mkdir(path, dryrun=False):
         os.makedirs(path)
 
 
-def modify_autojump_sh(etc_dir, dryrun=False):
+def modify_autojump_sh(etc_dir, share_dir, dryrun=False):
     """Append custom installation path to autojump.sh"""
     custom_install = "\
         \n# check custom install \
         \nif [ -s %s/autojump.${shell} ]; then \
             \n\tsource %s/autojump.${shell} \
-        \nfi\n" % (etc_dir, etc_dir)
+        \nfi\n" % (share_dir, share_dir)
 
     with open(os.path.join(etc_dir, 'autojump.sh'), 'a') as f:
         f.write(custom_install)
@@ -207,7 +207,7 @@ def main(args):
         cp('./bin/_j', zshshare_dir, args.dryrun)
 
         if args.custom_install:
-            modify_autojump_sh(etc_dir, args.dryrun)
+            modify_autojump_sh(etc_dir, share_dir, args.dryrun)
 
     show_post_installation_message(etc_dir, share_dir, bin_dir)
 


### PR DESCRIPTION
The `modify_autojump_sh` function in `install.py` patches the `autojump.sh` in the wrong way in case the user has chosen a different dest_dir.
In particular, if we consider a dest_dir set to "/usr/local/Cellar/autojump/22.2.2", it would write something like:

```
source /usr/local/Cellar/autojump/22.2.2/etc/profile.d/autojump.${shell}
```

which does not exist, since all the autojump.${shell} files are placed under the share_dir. The correct path would be:

```
/usr/local/Cellar/autojump/22.2.2/share/autojump/autojump.${shell}
```
