### PR TITLE
Autojump is repeatedly added to $PATH on repeated sourcing in Fish

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -1,8 +1,14 @@
 set -x AUTOJUMP_SOURCED 1
 
-# set user installation path
-if test -d ~/.autojump
-    set -x PATH ~/.autojump/bin $PATH
+# Set user installation path
+begin
+    set --local AUTOJUMP_BIN_PATH ~/.autojump/bin
+    if test -d $AUTOJUMP_BIN_PATH
+        # Add to PATH only if autojump not sourced yet
+        if not contains $AUTOJUMP_BIN_PATH $PATH
+            set -x PATH $AUTOJUMP_BIN_PATH $PATH
+        end
+    end
 end
 
 # Set ostype, if not set


### PR DESCRIPTION
Autojump path is repeatedly added to `$PATH` on repeated sourcing in Fish shell:

```
$ echo $PATH
/home/joe/.autojump/bin /home/joe/bin /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin
$ source ~/.config/fish/config.fish
$ echo $PATH
/home/joe/.autojump/bin /home/joe/.autojump/bin /home/joe/bin /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin
```

Sourcing is a common operation in Fish shell to update the current shell after making changes to `~/.config/fish/config.fish`

This commit prevents the repeated addition of Autojump path by checking if it is already in `$PATH`.