### PR TITLE
Handling of directories with spaces in Windows and Portability fixes

### DIFF
--- a/bin/autojump.bat
+++ b/bin/autojump.bat
@@ -1,2 +1,2 @@
 @echo off
-python %~dp0\autojump %*
+python "%~dp0\autojump" %*

--- a/bin/autojump.lua
+++ b/bin/autojump.lua
@@ -1,13 +1,15 @@
+local AUTOJUMP_DIR = debug.getinfo(1, "S").source:match[[^@?(.*[\/])[^\/]-$]] .. "..\\AutoJump"
+local AUTOJUMP_BIN_DIR = AUTOJUMP_DIR .. "\\bin"
 local AUTOJUMP_BIN = (AUTOJUMP_BIN_DIR or clink.get_env("LOCALAPPDATA") .. "\\autojump\\bin") .. "\\autojump"
 
 function autojump_add_to_database() 
-  os.execute("python " .. AUTOJUMP_BIN .. " --add " .. clink.get_cwd() .. " 2> " .. clink.get_env("TEMP") .. "\\autojump_error.txt")
+  os.execute("python " .. "\"" .. AUTOJUMP_BIN .. "\"" .. " --add " .. "\"" .. clink.get_cwd() .. "\"" .. " 2> " .. clink.get_env("TEMP") .. "\\autojump_error.txt")
 end
 
 clink.prompt.register_filter(autojump_add_to_database, 99)
 
 function autojump_completion(word)
-  for line in io.popen("python " .. AUTOJUMP_BIN .. " --complete " .. word):lines() do
+  for line in io.popen("python " .. "\"" .. AUTOJUMP_BIN .. "\"" ..  " --complete " .. word):lines() do
     clink.add_match(line)
   end
   return {} 

--- a/bin/j.bat
+++ b/bin/j.bat
@@ -17,5 +17,5 @@ if ERRORLEVEL 1 (
     echo try `autojump --help` for more information
   )
 ) else (
-  python %~dp0\autojump %* 
+  python "%~dp0\autojump" %*
 )

--- a/bin/j.bat
+++ b/bin/j.bat
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 
 echo %*|>nul findstr /rx \-.*
 if ERRORLEVEL 1 (
-  for /f %%i in ('python %~dp0\autojump %*') do set new_path=%%i
+  for /f %%i in ('python "%~dp0\autojump" %*') do set new_path=%%i
   if exist !new_path!\nul (
     echo !new_path!
 	pushd !new_path!

--- a/bin/jc.bat
+++ b/bin/jc.bat
@@ -2,7 +2,7 @@
 
 echo %*|>nul findstr /rx \-.*
 if ERRORLEVEL 1 (
-  %~dp0\j.bat %cd% %*
+  "%~dp0\j.bat" "%cd%" %*
 ) else (
-  python %~dp0\autojump %* 
+  python "%~dp0\autojump" %*
 )

--- a/bin/jco.bat
+++ b/bin/jco.bat
@@ -2,7 +2,7 @@
 
 echo %*|>nul findstr /rx \-.*
 if ERRORLEVEL 1 (
-  %~dp0\jc.bat %cd% %*
+  "%~dp0\jc.bat" "%cd%" %*
 ) else (
-  python %~dp0\autojump %* 
+  python "%~dp0\autojump" %*
 )

--- a/bin/jo.bat
+++ b/bin/jo.bat
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 
 echo %*|>nul findstr /rx \-.*
 if ERRORLEVEL 1 (
-  for /f %%i in ('python %~dp0\autojump %*') do set new_path=%%i
+  for /f %%i in ('python "%~dp0\autojump" %*') do set new_path=%%i
   if exist !new_path!\nul (
     start !new_path!
   ) else (

--- a/bin/jo.bat
+++ b/bin/jo.bat
@@ -11,5 +11,5 @@ if ERRORLEVEL 1 (
     echo try `autojump --help` for more information
   )
 ) else (
-  python %~dp0\autojump %* 
+  python "%~dp0\autojump" %*
 )


### PR DESCRIPTION
When used autojump with paths that contain spaces in Windows, batch files broke.
Also autojump.lua clink plugin should be able to work around this problems too.

Proposed solutions are in this merge requests. I've been testing them for months in my machine and everythink works flawlessly, so i decided to make these fixes public.