### PR TITLE
Updated the link to clink project

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ MacPorts also available:
 Windows
 -------
 
-Windows support is enabled by [clink](https://code.google.com/p/clink/)
+Windows support is enabled by [clink](https://github.com/mridgers/clink)
 which should be installed prior to installing autojump.
 
 ### MANUAL


### PR DESCRIPTION
clink project has moved from Google Code to Github.

Updated the link:
from https://code.google.com/p/clink/
to https://github.com/mridgers/clink