### PR TITLE
Regex characters cause breakage

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -279,7 +279,7 @@ def match_consecutive(needles, haystack, ignore_case=False):
     regex_no_sep_end = regex_no_sep + '$'
     regex_one_sep = regex_no_sep + sep + regex_no_sep
     # can't use compiled regex because of flags
-    regex_needle = regex_one_sep.join(needles).replace('\\', '\\\\') + regex_no_sep_end  # noqa
+    regex_needle = regex_one_sep.join(map(re.escape, needles)).replace('\\', '\\\\') + regex_no_sep_end  # noqa
     regex_flags = re.IGNORECASE | re.UNICODE if ignore_case else re.UNICODE
     found = lambda entry: re.search(
         regex_needle,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     py27,
     py32,
     py33,
-    py34
+    py34,
+    py35
 # ignore missing setup.py
 skipsdist = True
 


### PR DESCRIPTION
Regex-special characters (e.g. plus `+`) caused autojump to fail with `sre_constants.error`.
It was enough to map `re.escape()` to all needles in `match_consecutive()` function to remedy this.

Tests still pass.

If any refinements are required before this pull request can be merged, let me know and I'll apply them.