### PR TITLE
Set AUTOJUMP env variables using `set -gx`.

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -1,4 +1,4 @@
-set -x AUTOJUMP_SOURCED 1
+set -gx AUTOJUMP_SOURCED 1
 
 # set user installation path
 if test -d ~/.autojump
@@ -17,11 +17,11 @@ complete -x -c j -a '(autojump --complete (commandline -t))'
 
 # set error file location
 if test (uname) = "Darwin"
-    set -x AUTOJUMP_ERROR_PATH ~/Library/autojump/errors.log
+    set -gx AUTOJUMP_ERROR_PATH ~/Library/autojump/errors.log
 else if test -d "$XDG_DATA_HOME"
-    set -x AUTOJUMP_ERROR_PATH $XDG_DATA_HOME/autojump/errors.log
+    set -gx AUTOJUMP_ERROR_PATH $XDG_DATA_HOME/autojump/errors.log
 else
-    set -x AUTOJUMP_ERROR_PATH ~/.local/share/autojump/errors.log
+    set -gx AUTOJUMP_ERROR_PATH ~/.local/share/autojump/errors.log
 end
 
 if test ! -d (dirname $AUTOJUMP_ERROR_PATH)


### PR DESCRIPTION
Due to changes in the way fish handles variable lookup the fish autojump integration stopped working with fish version 2.3. ([d5f3a09](https://github.com/fish-shell/fish-shell/commit/d5f3a09ce932779346d521afe1ba0ffdcb1cbfa9) might be the offending commit). 

By exporting the needed variables globally it works also with fish 2.3.

This PR should fix https://github.com/wting/autojump/issues/423