### PR TITLE
Improve handling of multiple directory arguments

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -193,8 +193,8 @@ def find_matches(entries, needles, check_entries=True):
         lambda entry: not is_cwd(entry) and path_exists(entry),
         chain(
             match_consecutive(needles, data, ignore_case),
-            match_fuzzy(needles, data, ignore_case),
-            match_anywhere(needles, data, ignore_case)))
+            match_anywhere(needles, data, ignore_case),
+            match_fuzzy(needles, data, ignore_case)))
 
 
 def handle_tab_completion(needle, entries):

--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -32,7 +32,7 @@ def match_anywhere(needles, haystack, ignore_case=False):
         ]
 
         result = [
-            (path='/moo/foo/baz', weight=10),
+            (path='/foo/bar/baz', weight=10),
             (path='/foo/baz', weight=10),
         ]
     """

--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -20,14 +20,15 @@ else:
 def match_anywhere(needles, haystack, ignore_case=False):
     """
     Matches needles anywhere in the path as long as they're in the same (but
-    not necessary consecutive) order.
+    not necessary consecutive) order, and the last needle is at the end.
 
     For example:
         needles = ['foo', 'baz']
-        regex needle = r'.*foo.*baz.*'
+        regex needle = r'foo.*/.*baz[^/]*$'
         haystack = [
             (path='/foo/bar/baz', weight=10),
             (path='/baz/foo/bar', weight=10),
+            (path='/foo/baz/bar', weight=11),
             (path='/foo/baz', weight=10),
         ]
 
@@ -36,8 +37,9 @@ def match_anywhere(needles, haystack, ignore_case=False):
             (path='/foo/baz', weight=10),
         ]
     """
-    regex_needle = '.*' + '.*'.join(imap(re.escape, needles)) + '.*'
-    regex_flags = re.IGNORECASE | re.UNICODE if ignore_case else re.UNICODE
+    regex_some_seps = '.*' + os.sep + '.*'
+    regex_no_sep_end = '[^' + os.sep + ']*$'
+    regex_needle = regex_some_seps.join(imap(re.escape, needles)) + regex_no_sep_end
     found = lambda haystack: re.search(
         regex_needle,
         haystack.path,


### PR DESCRIPTION
**1**: Given a database:
```
20   /foobar
10   /foo/bar
```
Executing `j foo bar`, or `jc bar` from within `/foo` would both incorrectly match `/foobar` instead of the correct child directory `/foo/bar`.



**2**: Given a database:
```
20   /foo/bar/baz
10   /foo/bar
```
Executing the same commands would both match `/foo/bar/baz`. 

Also, fuzzy "last resort" matches were previously prioritized over non-consecutive matches, which they shouldn't have been.