### PR TITLE
Fix jumping to paths containing spaces on Windows

### DIFF
--- a/bin/j.bat
+++ b/bin/j.bat
@@ -3,15 +3,15 @@ setlocal EnableDelayedExpansion
 
 echo %*|>nul findstr /rx \-.*
 if ERRORLEVEL 1 (
-  for /f %%i in ('python "%~dp0\autojump" %*') do set new_path=%%i
+  for /f "delims=" %%i in ('python "%~dp0\autojump" %*') do set new_path=%%i
   if exist !new_path!\nul (
     echo !new_path!
-	pushd !new_path!
-	REM endlocal is necessary so that we can change directory for outside of this script
-	REM but will automatically popd. We mush pushd twice to work around this. 
-	pushd !new_path!
-	endlocal
-	popd
+    pushd !new_path!
+    REM endlocal is necessary so that we can change directory for outside of this script
+    REM but will automatically popd. We mush pushd twice to work around this.
+    pushd !new_path!
+    endlocal
+    popd
   ) else (
     echo autojump: directory %* not found
     echo try `autojump --help` for more information

--- a/bin/jo.bat
+++ b/bin/jo.bat
@@ -3,9 +3,9 @@ setlocal EnableDelayedExpansion
 
 echo %*|>nul findstr /rx \-.*
 if ERRORLEVEL 1 (
-  for /f %%i in ('python "%~dp0\autojump" %*') do set new_path=%%i
+  for /f "delims=" %%i in ('python "%~dp0\autojump" %*') do set new_path=%%i
   if exist !new_path!\nul (
-    start !new_path!
+    start "" "explorer" !new_path!
   ) else (
     echo autojump: directory %* not found
     echo try `autojump --help` for more information


### PR DESCRIPTION
I was running into an issue when I tried to autojump to a path containing spaces on Windows. This is seemingly unrelated to #381. The problem was that the `for /f` command defaults to splitting at spaces, which results in an invalid path.  

Similarly, with `jo` there was a problem with spaces. The solution in this case was to call Explorer directly and pass the directory as a parameter. 
