### PR TITLE
Autojump is available on Debian stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ autojump is included in the following distro repositories, please use
 relevant package management utilities to install (e.g. yum, apt-get,
 etc):
 
--   Debian testing/unstable, Ubuntu, Linux Mint
+-   Debian, Ubuntu, Linux Mint
 
     All Debian-derived distros require manual activation for policy
     reasons, please see `/usr/share/doc/autojump/README.Debian`.


### PR DESCRIPTION
Autojump is on Debian repos since Wheezy which is now old-stable.