### PR TITLE
{/usr/bin/ => }env to work with termux

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 """
   Copyright © 2008-2012 Joel Schaerer

--- a/bin/autojump_data.py
+++ b/bin/autojump_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 

--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 import os
 import re

--- a/bin/autojump_utils.py
+++ b/bin/autojump_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 

--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 

--- a/tests/unit/autojump_match_test.py
+++ b/tests/unit/autojump_match_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/tests/unit/autojump_utils_test.py
+++ b/tests/unit/autojump_utils_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 


### PR DESCRIPTION
was setting up [termux](https://termux.com/) with autojump and it apparently doesn't use the standard `/usr/bin/env` so that was breaking things. this got it working for me, not sure if there are larger implications of this change though o.O

P.S. not totally sure how it resolves it's packages, but if it's easy to get this in a repo somewhere on the interwebz where one could `apt install autojump` from termux, that'd be awesome ![](https://dujrsrsgsd3nh.cloudfront.net/img/emoticons/awesome-1417754492.png)