### PR TITLE
Add AUTOJUMP_SOURCED to tcsh activation file

### DIFF
--- a/bin/autojump.tcsh
+++ b/bin/autojump.tcsh
@@ -1,3 +1,6 @@
+# set the environment variable to let autojump know it's been loaded
+setenv AUTOJUMP_SOURCED 1
+
 # set user installation paths
 if (-d ~/.autojump/bin) then
     set path = (~/.autojump/bin path)


### PR DESCRIPTION
I know I'm basically the only person that still uses tcsh for anything, but the activation script is missing the AUTOJUMP_SOURCED environment variable.