### PR TITLE
Fix variable leakage

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -59,6 +59,7 @@ j() {
         return
     fi
 
+    local output
     output="$(autojump ${@})"
     if [[ -d "${output}" ]]; then
         if [ -t 1 ]; then  # if stdout is a terminal, use colors
@@ -94,6 +95,7 @@ jo() {
         return
     fi
 
+    local output
     output="$(autojump ${@})"
     if [[ -d "${output}" ]]; then
         case ${OSTYPE} in

--- a/bin/autojump.sh
+++ b/bin/autojump.sh
@@ -14,7 +14,7 @@ fi
 
 # prevent circular loop for sh shells
 if [ "${shell}" = "sh" ]; then
-    return 0
+    :
 
 # check local install
 elif [ -s ~/.autojump/share/autojump/autojump.${shell} ]; then
@@ -24,3 +24,5 @@ elif [ -s ~/.autojump/share/autojump/autojump.${shell} ]; then
 elif [ -s /usr/local/share/autojump/autojump.${shell} ]; then
     source /usr/local/share/autojump/autojump.${shell}
 fi
+
+unset shell


### PR DESCRIPTION
Autojump leaks two variables into the shell context, `output` and `shell`. You can observe this using `echo "$output"` or `echo "$shell"` in a shell using autojump.

It looks like the other shells may have the same problem regarding `output`, but I only fixed Bash as that's what I am using myself and was able to test.