### PR TITLE
Fix inconsisent file indexing in find_matches

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -325,7 +325,7 @@ def main(args):  # noqa
             print_local(
                 get_ith_path(
                     tab_index,
-                    find_matches(entries, [tab_needle]),
+                    find_matches(entries, [tab_needle], check_entries=False),
                 ),
             )
         else:


### PR DESCRIPTION
When user applies tab completion and gets the list of possible paths to jump to, those paths contains the deleted/invalid ones. 
However, in the next stage, when the user selects an path index to jump to, autojump filters out the invalid paths and causes inconsistent indexing.

This PR applies a simple fix to keep the invalid paths during the index-based jump. This way, user will go to the exact path s/he sees in the terminal.