### PR TITLE
WIP:Fix improper backslash handeling 

### DIFF
--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -75,9 +75,10 @@ def match_consecutive(needles, haystack, ignore_case=False):
             (path='/foo/baz', weight=10),
         ]
     """
-    regex_no_sep = '[^' + os.sep + ']*'
+    sep = '\\\\' if os.sep == '\\' else os.sep
+    regex_no_sep = '[^' + sep + ']*'
     regex_no_sep_end = regex_no_sep + '$'
-    regex_one_sep = regex_no_sep + os.sep + regex_no_sep
+    regex_one_sep = regex_no_sep + sep + regex_no_sep
     regex_needle = regex_one_sep.join(imap(re.escape, needles)) + regex_no_sep_end
     regex_flags = re.IGNORECASE | re.UNICODE if ignore_case else re.UNICODE
     found = lambda entry: re.search(

--- a/tests/unit/autojump_utils_test.py
+++ b/tests/unit/autojump_utils_test.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import platform
 
 import mock
 import pytest
@@ -21,6 +22,7 @@ from autojump_utils import surround_quotes
 from autojump_utils import take
 from autojump_utils import unico
 
+is_windows = platform.system() == 'Windows'
 
 if is_python3():
     os.getcwdu = os.getcwd
@@ -80,11 +82,15 @@ def test_surround_quotes_in_bash(_):
 def test_dont_surround_quotes_not_in_bash(_):
     assert surround_quotes('foo') == 'foo'
 
-
+@pytest.mark.skipif(is_windows, reason='Different reference data for path.')
 def test_sanitize():
     assert sanitize([]) == []
     assert sanitize([r'/foo/bar/', r'/']) == [u('/foo/bar'), u('/')]
 
+@pytest.mark.skipif(not is_windows, reason='Different reference data for path.')
+def test_sanitize_on_windows():
+    assert sanitize([]) == []
+    assert sanitize(['C:\\foo\\bar\\', 'C:\\']) == [u('C:\\foo\\bar'), u('C:')]
 
 @pytest.mark.skipif(is_python3(), reason='Unicode sucks.')
 def test_unico():


### PR DESCRIPTION
Fixes #436 #522 and #543 

Root cause was the improper backslash handeling. I have implimented the fix suggested in #436 and ammended the reference data in the tests so they now pass on Windows. I also created an `is_windows` variable bassed on detecting the platform, and skipped tests that were failing due to differences in the path sep and drive character.