### PR TITLE
Add Windows CI with appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # For Python versions available on Appveyor, see
     # https://www.appveyor.com/docs/windows-images-software/#python
 
-    - PYTHON: "C:\\C:\Python26-x64"
+    - PYTHON: "C:\\Python26-x64"
       TOX_ENV: "py26"
 
     - PYTHON: "C:\\Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,9 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       TOX_ENV: "py36"
 
+    - PYTHON: "C:\\Python37-x64"
+      TOX_ENV: "py37"
+
 install:
   - "%PYTHON%\\python.exe -m pip install tox"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # https://www.appveyor.com/docs/windows-images-software/#python
+
+    - PYTHON: "C:\\C:\Python26-x64"
+      TOX_ENV: "py26"
+
+    - PYTHON: "C:\\Python27-x64"
+      TOX_ENV: "py27"
+
+    - PYTHON: "C:\\Python33-x64"
+      TOX_ENV: "py33"
+
+    - PYTHON: "C:\\Python34-x64"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python36-x64"
+      TOX_ENV: "py36"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install tox"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m tox -e %TOX_ENV%"

--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -75,9 +75,10 @@ def match_consecutive(needles, haystack, ignore_case=False):
             (path='/foo/baz', weight=10),
         ]
     """
-    regex_no_sep = '[^' + os.sep + ']*'
+    sep = '\\\\' if os.sep == '\\' else os.sep
+    regex_no_sep = '[^' + sep + ']*'
     regex_no_sep_end = regex_no_sep + '$'
-    regex_one_sep = regex_no_sep + os.sep + regex_no_sep
+    regex_one_sep = regex_no_sep + sep + regex_no_sep
     regex_needle = regex_one_sep.join(imap(re.escape, needles)) + regex_no_sep_end
     regex_flags = re.IGNORECASE | re.UNICODE if ignore_case else re.UNICODE
     found = lambda entry: re.search(

--- a/tests/unit/autojump_utils_test.py
+++ b/tests/unit/autojump_utils_test.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import platform
 
 import mock
 import pytest
@@ -21,6 +22,7 @@ from autojump_utils import surround_quotes
 from autojump_utils import take
 from autojump_utils import unico
 
+is_windows = platform.system() == 'Windows'
 
 if is_python3():
     os.getcwdu = os.getcwd
@@ -80,11 +82,15 @@ def test_surround_quotes_in_bash(_):
 def test_dont_surround_quotes_not_in_bash(_):
     assert surround_quotes('foo') == 'foo'
 
-
+@pytest.mark.skipif(is_windows, reason='Different reference data for path.')
 def test_sanitize():
     assert sanitize([]) == []
     assert sanitize([r'/foo/bar/', r'/']) == [u('/foo/bar'), u('/')]
 
+@pytest.mark.skipif(not is_windows, reason='Different reference data for path.')
+def test_sanitize_on_windows():
+    assert sanitize([]) == []
+    assert sanitize(['C:\\foo\\bar\\', 'C:\\']) == [u('C:\\foo\\bar'), u('C:')]
 
 @pytest.mark.skipif(is_python3(), reason='Unicode sucks.')
 def test_unico():


### PR DESCRIPTION
A follow on PR from #561 

Included a `appveyor.yaml` that uses tox to run tests on Windows. Tests currently pass/fail for the following reasons:

- Python 2.6: Fail - pip is not installed on Windows for Python 2.6
- Python 2.7: Passing
- Python 3.3: Fail - Needs Python 3.4 or greater to run the latest version of dependencies listed in tox.ini
- Python 3.4: Passing
- Python 3.5: Passing
- Python 3.6: Passing
- Python 3.7: Passing