### PR TITLE
Refactor tests to use platform specific path format in test data

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # For Python versions available on Appveyor, see
     # https://www.appveyor.com/docs/windows-images-software/#python
 
-    - PYTHON: "C:\\C:\Python26-x64"
+    - PYTHON: "C:\\Python26-x64"
       TOX_ENV: "py26"
 
     - PYTHON: "C:\\Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,9 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       TOX_ENV: "py36"
 
+    - PYTHON: "C:\\Python37-x64"
+      TOX_ENV: "py37"
+
 install:
   - "%PYTHON%\\python.exe -m pip install tox"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # https://www.appveyor.com/docs/windows-images-software/#python
+
+    - PYTHON: "C:\\C:\Python26-x64"
+      TOX_ENV: "py26"
+
+    - PYTHON: "C:\\Python27-x64"
+      TOX_ENV: "py27"
+
+    - PYTHON: "C:\\Python33-x64"
+      TOX_ENV: "py33"
+
+    - PYTHON: "C:\\Python34-x64"
+      TOX_ENV: "py34"
+
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: "py35"
+
+    - PYTHON: "C:\\Python36-x64"
+      TOX_ENV: "py36"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install tox"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m tox -e %TOX_ENV%"

--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -75,9 +75,10 @@ def match_consecutive(needles, haystack, ignore_case=False):
             (path='/foo/baz', weight=10),
         ]
     """
-    regex_no_sep = '[^' + os.sep + ']*'
+    sep = '\\\\' if os.sep == '\\' else os.sep
+    regex_no_sep = '[^' + sep + ']*'
     regex_no_sep_end = regex_no_sep + '$'
-    regex_one_sep = regex_no_sep + os.sep + regex_no_sep
+    regex_one_sep = regex_no_sep + sep + regex_no_sep
     regex_needle = regex_one_sep.join(imap(re.escape, needles)) + regex_no_sep_end
     regex_flags = re.IGNORECASE | re.UNICODE if ignore_case else re.UNICODE
     found = lambda entry: re.search(

--- a/tests/unit/autojump_match_test.py
+++ b/tests/unit/autojump_match_test.py
@@ -20,53 +20,53 @@ class TestMatchAnywhere(object):
     entry3 = Entry('/foo/baz', 10)
     entry4 = Entry('/中/zhong/国/guo', 10)
     entry5 = Entry('/is\'t/this/a/b*tchin/edge/case?', 10)
+
     win_entry1 = Entry('C:\\foo\\bar\\baz', 10)
-    win_entry2 = Entry(r'D:\Program Files (x86)\GIMP', 10)
-    win_entry3 = Entry(r'C:\Windows\System32', 10)
+    win_entry2 = Entry('C:\\baz\\foo\\bar', 10)
+    win_entry3 = Entry('C:\\foo\\baz', 10)
+    win_entry4 = Entry('C:\\中\\zhong\\国\\guo', 10)
+    win_entry5 = Entry('C:\\is\'t\\this\\a\\b*tchin\\edge\\case?', 10)
 
     @pytest.fixture
     def haystack(self):
-        return [
-            self.entry1,
-            self.entry2,
-            self.entry3,
-            self.entry4,
-            self.entry5,
-        ]
 
-    @pytest.fixture
-    def windows_haystack(self):
-        return [self.win_entry1, self.win_entry2, self.win_entry3]
+        if platform.system() == 'Windows':
+            return [
+                self.win_entry1,
+                self.win_entry2,
+                self.win_entry3,
+                self.win_entry4,
+                self.win_entry5,
+            ]
+        else:
+            return [
+                self.entry1,
+                self.entry2,
+                self.entry3,
+                self.entry4,
+                self.entry5,
+            ]
 
     def test_single_needle(self, haystack):
-        assert list(match_anywhere(['bar'], haystack)) == [self.entry1, self.entry2]
+        assert list(match_anywhere(['bar'], haystack)) == [haystack[0], haystack[1]]
 
     def test_consecutive(self, haystack):
         assert list(match_anywhere(['foo', 'bar'], haystack)) \
-            == [self.entry1, self.entry2]
+            == [haystack[0], haystack[1]]
         assert list(match_anywhere(['bar', 'foo'], haystack)) == []
 
     def test_skip(self, haystack):
-        assert list(match_anywhere(['baz', 'bar'], haystack)) == [self.entry2]
-        assert list(match_anywhere(['中', '国'], haystack)) == [self.entry4]
+        assert list(match_anywhere(['baz', 'bar'], haystack)) == [haystack[1]]
+        assert list(match_anywhere(['中', '国'], haystack)) == [haystack[3]]
 
     def test_ignore_case(self, haystack):
         assert list(match_anywhere(['bAz', 'bAR'], haystack, ignore_case=True)) \
-            == [self.entry2]
-
-    def test_backslashes_for_windows_paths(self, windows_haystack):
-        # https://github.com/wting/autojump/issues/281
-        assert list(match_anywhere(['foo', 'baz'], windows_haystack)) \
-            == [self.win_entry1]
-        assert list(match_anywhere(['program', 'gimp'], windows_haystack, True)) \
-            == [self.win_entry2]
-        assert list(match_anywhere(['win', '32'], windows_haystack, True)) \
-            == [self.win_entry3]
+            == [haystack[1]]
 
     def test_wildcard_in_needle(self, haystack):
         # https://github.com/wting/autojump/issues/402
         assert list(match_anywhere(['*', 'this'], haystack)) == []
-        assert list(match_anywhere(['this', '*'], haystack)) == [self.entry5]
+        assert list(match_anywhere(['this', '*'], haystack)) == [haystack[4]]
 
 
 class TestMatchConsecutive(object):
@@ -77,68 +77,50 @@ class TestMatchConsecutive(object):
     entry4 = Entry('/中/zhong/国/guo', 10)
     entry5 = Entry('/日/本', 10)
     entry6 = Entry('/is\'t/this/a/b*tchin/edge/case?', 10)
-    win_entry1 = Entry(r'C:\Foo\Bar\Baz', 10)
-    win_entry2 = Entry(r'D:\Program Files (x86)\GIMP', 10)
-    win_entry3 = Entry(r'C:\Windows\System32', 10)
-    win_entry4 = Entry('C:\\is\'t\\this\\a\\b*tchin\\edge\\case?', 10)
+
+    win_entry1 = Entry('C:\\foo\\bar\\baz', 10)
+    win_entry2 = Entry('C:\\baz\\foo\\bar', 10)
+    win_entry3 = Entry('C:\\foo\\baz', 10)
+    win_entry4 = Entry('C:\\中\\zhong\\国\\guo', 10)
+    win_entry5 = Entry('C:\\日\\本', 10)
+    win_entry6 = Entry('C:\\is\'t\\this\\a\\b*tchin\\edge\\case?', 10)
 
     @pytest.fixture
     def haystack(self):
-        return [
-            self.entry1,
-            self.entry2,
-            self.entry3,
-            self.entry4,
-            self.entry5,
-        ]
 
-    @pytest.fixture
-    def windows_haystack(self):
-        return [self.win_entry1, self.win_entry2, self.win_entry3, self.win_entry4]
+        if platform.system() == 'Windows':
+            return [
+                self.win_entry1,
+                self.win_entry2,
+                self.win_entry3,
+                self.win_entry4,
+                self.win_entry5,
+                self.win_entry6,
+            ]
+        else:
+            return [
+                self.entry1,
+                self.entry2,
+                self.entry3,
+                self.entry4,
+                self.entry5,
+                self.entry6,
+            ]
 
-    @pytest.mark.skipif(is_windows, reason='Different reference data for path.')
     def test_single_needle(self, haystack):
-        assert list(match_consecutive(['baz'], haystack)) == [self.entry1, self.entry3]
-        assert list(match_consecutive(['本'], haystack)) == [self.entry5]
+        assert list(match_consecutive(['baz'], haystack)) == [haystack[0], haystack[2]]
+        assert list(match_consecutive(['本'], haystack)) == [haystack[4]]
 
-    @pytest.mark.skipif(is_windows, reason='Different reference data for path.')
     def test_consecutive(self, haystack):
-        assert list(match_consecutive(['bar', 'baz'], haystack)) == [self.entry1]
-        assert list(match_consecutive(['foo', 'bar'], haystack)) == [self.entry2]
-        assert list(match_consecutive(['国', 'guo'], haystack)) == [self.entry4]
+        assert list(match_consecutive(['bar', 'baz'], haystack)) == [haystack[0]]
+        assert list(match_consecutive(['foo', 'bar'], haystack)) == [haystack[1]]
+        assert list(match_consecutive(['国', 'guo'], haystack)) == [haystack[3]]
         assert list(match_consecutive(['bar', 'foo'], haystack)) == []
 
-    @pytest.mark.skipif(is_windows, reason='Different reference data for path.')
     def test_ignore_case(self, haystack):
         assert list(match_consecutive(['FoO', 'bAR'], haystack, ignore_case=True)) \
-            == [self.entry2]
+            == [haystack[1]]
 
-    def test_windows_ignore_case(self, windows_haystack):
-        assert list(match_consecutive(['gimp'], windows_haystack, True)) == [self.win_entry2]
-
-    @pytest.mark.skipif(not is_windows, reason='Different path seperator')
-    def test_backslashes_for_windows_paths(self, windows_haystack):
-        # https://github.com/wting/autojump/issues/418
-        assert list(match_consecutive(['program', 'gimp'], windows_haystack, True)) \
-            == [self.win_entry2]
-
-    @pytest.mark.skipif(not is_windows, reason='Different path seperator')
-    def test_foo_bar_baz(self, windows_haystack):
-        # https://github.com/wting/autojump/issues/418
-        assert list(match_consecutive(['bar', 'baz'], windows_haystack, ignore_case=True)) \
-            == [self.win_entry1]
-
-    @pytest.mark.skipif(not is_windows, reason='Different path seperator')
-    def test_thing(self, windows_haystack):
-        assert list(match_consecutive(['win', '32'], windows_haystack, True)) \
-            == [self.win_entry3]
-
-    @pytest.mark.skipif(is_windows, reason='Different reference data for path.')
     def test_wildcard_in_needle(self, haystack):
         assert list(match_consecutive(['*', 'this'], haystack)) == []
-        assert list(match_consecutive(['*', 'edge', 'case'], haystack)) == [self.entry6]
-
-    @pytest.mark.skipif(not is_windows, reason='Different path seperator')
-    def test_wildcard_in_needle(self, windows_haystack):
-        assert list(match_consecutive(['*', 'this'], windows_haystack)) == []
-        assert list(match_consecutive(['*', 'edge', 'case'], windows_haystack)) == [self.win_entry4]
+        assert list(match_consecutive(['*', 'edge', 'case'], haystack)) == [haystack[5]]

--- a/tests/unit/autojump_utils_test.py
+++ b/tests/unit/autojump_utils_test.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import platform
 
 import mock
 import pytest
@@ -21,6 +22,7 @@ from autojump_utils import surround_quotes
 from autojump_utils import take
 from autojump_utils import unico
 
+is_windows = platform.system() == 'Windows'
 
 if is_python3():
     os.getcwdu = os.getcwd
@@ -80,11 +82,15 @@ def test_surround_quotes_in_bash(_):
 def test_dont_surround_quotes_not_in_bash(_):
     assert surround_quotes('foo') == 'foo'
 
-
+@pytest.mark.skipif(is_windows, reason='Different reference data for path.')
 def test_sanitize():
     assert sanitize([]) == []
     assert sanitize([r'/foo/bar/', r'/']) == [u('/foo/bar'), u('/')]
 
+@pytest.mark.skipif(not is_windows, reason='Different reference data for path.')
+def test_sanitize_on_windows():
+    assert sanitize([]) == []
+    assert sanitize(['C:\\foo\\bar\\', 'C:\\']) == [u('C:\\foo\\bar'), u('C:')]
 
 @pytest.mark.skipif(is_python3(), reason='Unicode sucks.')
 def test_unico():


### PR DESCRIPTION
A follow on PR from #561 and #562.  

A bit of refactoring to reduce duplication of tests involving Windows and linux path formats. 

- The `haystack` fixture now returns test path data based on the format of the platform its running on.  
- The examples used or both windows and linux paths are now the same in terms of there folder names. 
- Returned results are compared to the indexed haystack in the assertions checks e.g. `assert foo() == [haystack[0]]`