### PR TITLE
Use explorer.exe as file manager if available

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -96,20 +96,24 @@ jo() {
 
     output="$(autojump ${@})"
     if [[ -d "${output}" ]]; then
-        case ${OSTYPE} in
-            linux*)
-                xdg-open "${output}"
-                ;;
-            darwin*)
-                open "${output}"
-                ;;
-            cygwin)
-                cygstart "" $(cygpath -w -a ${output})
-                ;;
-            *)
-                echo "Unknown operating system: ${OSTYPE}." 1>&2
-                ;;
-        esac
+        if command -v explorer.exe >/dev/null 2>&1; then
+            explorer.exe "${output}"
+        else
+            case ${OSTYPE} in
+                linux*)
+                    xdg-open "${output}"
+                    ;;
+                darwin*)
+                    open "${output}"
+                    ;;
+                cygwin)
+                    cygstart "" $(cygpath -w -a ${output})
+                    ;;
+                *)
+                    echo "Unknown operating system: ${OSTYPE}." 1>&2
+                    ;;
+            esac
+        fi
     else
         echo "autojump: directory '${@}' not found"
         echo "\n${output}\n"

--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -83,15 +83,19 @@ end
 function jo
     set -l output (autojump $argv)
     if test -d "$output"
-        switch $OSTYPE
-            case 'linux*'
-                xdg-open (autojump $argv)
-            case 'darwin*'
-                open (autojump $argv)
-            case cygwin
-                cygstart "" (cygpath -w -a (pwd))
-            case '*'
-                __aj_err "Unknown operating system: \"$OSTYPE\""
+        if command --search explorer.exe >/dev/null 2>&1 do
+            explorer.exe (autojump $argv)
+        else
+            switch $OSTYPE
+                case 'linux*'
+                    xdg-open (autojump $argv)
+                case 'darwin*'
+                    open (autojump $argv)
+                case cygwin
+                    cygstart "" (cygpath -w -a (pwd))
+                case '*'
+                    __aj_err "Unknown operating system: \"$OSTYPE\""
+            end
         end
     else
         __aj_err "autojump: directory '"$argv"' not found"

--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -91,20 +91,24 @@ jo() {
     setopt localoptions noautonamedirs
     local output="$(autojump ${@})"
     if [[ -d "${output}" ]]; then
-        case ${OSTYPE} in
-            linux*)
-                xdg-open "${output}"
-                ;;
-            darwin*)
-                open "${output}"
-                ;;
-            cygwin)
-                cygstart "" $(cygpath -w -a ${output})
-                ;;
-            *)
-                echo "Unknown operating system: ${OSTYPE}" 1>&2
-                ;;
-        esac
+        if command -v explorer.exe >/dev/null 2>&1; then
+            explorer.exe "${output}"
+        else
+            case ${OSTYPE} in
+                linux*)
+                    xdg-open "${output}"
+                    ;;
+                darwin*)
+                    open "${output}"
+                    ;;
+                cygwin)
+                    cygstart "" $(cygpath -w -a ${output})
+                    ;;
+                *)
+                    echo "Unknown operating system: ${OSTYPE}" 1>&2
+                    ;;
+            esac
+        fi
     else
         echo "autojump: directory '${@}' not found"
         echo "\n${output}\n"


### PR DESCRIPTION
This change makes 'jo' command check command 'explorer.exe' existance and use it if available. Instead it uses default behaviour.

This is needed to make this command normally work in WSL (Windows Subsystem for Linux).

Closes #575 
