### PR TITLE
Change "source" to "." in autojump.sh

### DIFF
--- a/bin/autojump.sh
+++ b/bin/autojump.sh
@@ -18,9 +18,9 @@ if [ "${shell}" = "sh" ]; then
 
 # check local install
 elif [ -s ~/.autojump/share/autojump/autojump.${shell} ]; then
-    source ~/.autojump/share/autojump/autojump.${shell}
+    . ~/.autojump/share/autojump/autojump.${shell}
 
 # check global install
 elif [ -s /usr/local/share/autojump/autojump.${shell} ]; then
-    source /usr/local/share/autojump/autojump.${shell}
+    . /usr/local/share/autojump/autojump.${shell}
 fi


### PR DESCRIPTION
Hi @wting thank you very much for autojump! Amazingly useful.

This PR makes the file more POSIX-compliant, which is useful in some OSs that link `/bin/sh` to secondary shells for performance improvements while still using `bash|zsh|...` as the default shell

References:
- https://wiki.ubuntu.com/DashAsBinSh
- padde/jump.vim#3