### PR TITLE
remove autocomplete extra information

### DIFF
--- a/bin/_j
+++ b/bin/_j
@@ -1,6 +1,18 @@
 #compdef j
 cur=${words[2, -1]}
 
-autojump --complete ${=cur[*]} | while read i; do
-    compadd -U "$i";
+integer i=1
+declare -A displayMap
+
+autojump --complete "${=cur[*]}" | while read c; do
+    hidden=$(echo "$c" | sed 's/\(.*__[0-9][0-9]*__\).*/\1/')
+    display=$(echo "$c" | sed 's/.*__[0-9][0-9]*__\(.*\)/\1/')
+
+    (( $+displayMap[$display] )) && continue
+    displayMap[$display]=true
+    
+    compadd -V $i -U "$display";
+    i=$((i+1))
 done
+
+(( $i > 2 )) && compadd -V $i -U "${=cur[*]}"


### PR DESCRIPTION
this pr adds information in autocomplete for zsh

# how was:

`<What I entered>__<int>__<actual completion>`

# how should be

`<actual completion>`

![image](https://user-images.githubusercontent.com/16441524/87556400-fb2d6a00-c68c-11ea-948a-d99213c56804.png)

