### PR TITLE
docs: fix simple typo, requres -> requires

### DIFF
--- a/bin/autojump_utils.py
+++ b/bin/autojump_utils.py
@@ -194,7 +194,7 @@ def surround_quotes(string):
     path outputs with quotes.
     """
     if in_bash() and string:
-        # Python 2.6 requres field numbers
+        # Python 2.6 requires field numbers
         return '"{0}"'.format(string)
     return string
 


### PR DESCRIPTION
There is a small typo in bin/autojump_utils.py.

Should read `requires` rather than `requres`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md