### PR TITLE
Switch default color for autocompleted text to green

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -54,7 +54,7 @@ function j
                 cd $argv
             else
                 if test -d "$output"
-                    set_color red
+                    set_color green
                     echo $output
                     set_color normal
                     cd $output


### PR DESCRIPTION
Red is usually used for notifying an error or command failure. Switch the default autocompleted text color to green to better signify that things went right