### PR TITLE
Change output dir color form Red to Green for bash

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -62,7 +62,7 @@ j() {
     output="$(autojump ${@})"
     if [[ -d "${output}" ]]; then
         if [ -t 1 ]; then  # if stdout is a terminal, use colors
-                echo -e "\\033[31m${output}\\033[0m"
+                echo -e "\\033[32m${output}\\033[0m"
         else
                 echo -e "${output}"
         fi


### PR DESCRIPTION
Similar to [ Switch default color for autocompleted text to green #631 ](
https://github.com/wting/autojump/pull/631#issue-634433283) but for bash.

Green makes more sense

