### PR TITLE
Keep path from growing by checking it bin dir exists - fish

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -2,7 +2,7 @@ set -gx AUTOJUMP_SOURCED 1
 
 # set user installation path
 if test -d ~/.autojump
-    set -x PATH ~/.autojump/bin $PATH
+    contains ~/.autojump/bin $PATH or set -x PATH ~/.autojump/bin $PATH
 end
 
 # Set ostype, if not set


### PR DESCRIPTION
You can test by doing source <checkout>/bin/autojump.fish and then echo $PATH and seeing that path doesn't grow.

