### PR TITLE
Fix duplicate matches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v1.4.0
   hooks:
   - id: autopep8-wrapper
-    language_version: python2
+    language_version: python3
     args:
     - --in-place
     - --aggressive
@@ -11,40 +11,40 @@ repos:
     - --ignore=E731
     - --max-line-length=131
   - id: check-added-large-files
-    language_version: python2
+    language_version: python3
   - id: check-ast
-    language_version: python2
+    language_version: python3
   - id: check-case-conflict
-    language_version: python2
+    language_version: python3
   - id: check-docstring-first
-    language_version: python2
+    language_version: python3
   - id: debug-statements
-    language_version: python2
+    language_version: python3
   - id: double-quote-string-fixer
-    language_version: python2
+    language_version: python3
   - id: end-of-file-fixer
-    language_version: python2
+    language_version: python3
     exclude_types: [batch, lua]
   - id: fix-encoding-pragma
-    language_version: python2
+    language_version: python3
   - id: flake8
-    language_version: python2
+    language_version: python3
     args:
     - --max-complexity=10
     - --max-line-length=131
     - --ignore=E402,E731
     - --exclude=bin/autojump_argparse.py
   - id: name-tests-test
-    language_version: python2
+    language_version: python3
   - id: requirements-txt-fixer
-    language_version: python2
+    language_version: python3
   - id: trailing-whitespace
-    language_version: python2
+    language_version: python3
 - repo: git@github.com:asottile/reorder_python_imports.git
   rev: v1.1.1
   hooks:
   - id: reorder-python-imports
-  language_version: python2
+  language_version: python3
 - repo: git@github.com:asottile/add-trailing-comma
   rev: v0.7.0
   hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: python
 
-python: 2.7
+python: 3.9
 
 env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py32
-  - TOX_ENV=py33
-  - TOX_ENV=py34
+  - TOX_ENV=py39
   - TOX_ENV=flake8
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test-xfail: pre-commit
 
 .PHONY: test-fast
 test-fast: pre-commit
-	@tox -e py27
+	@tox -e py39
 
 .PHONY: clean
 clean:

--- a/bin/autojump
+++ b/bin/autojump
@@ -196,11 +196,11 @@ def find_matches(entries, needles, check_entries=True):
 
     return ifilter(
         lambda entry: not is_cwd(entry) and path_exists(entry),
-        chain(
+        set(chain(
             match_consecutive(needles, data, ignore_case),
             match_fuzzy(needles, data, ignore_case),
             match_anywhere(needles, data, ignore_case),
-        ),
+        )),
     )
 
 

--- a/bin/autojump
+++ b/bin/autojump
@@ -129,8 +129,8 @@ def parse_arguments():
         help='show database entries and their key weights',
     )
     parser.add_argument(
-        '-v', '--version', action='version', version='%(prog)s v' +
-        VERSION, help='show version information',
+        '-v', '--version', action='version', version='%(prog)s v' + VERSION,
+        help='show version information',
     )
 
     return parser.parse_args()

--- a/bin/autojump.py
+++ b/bin/autojump.py
@@ -1,0 +1,1 @@
+autojump

--- a/tests/integration/autojump_test.py
+++ b/tests/integration/autojump_test.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+import sys
+
+sys.path.append(os.path.join(os.getcwd(), 'bin'))  # noqa
+from autojump import find_matches
+from autojump_data import entriefy
+
+
+def test_find_matches_returns_unique_results(tmpdir):
+    path = str(tmpdir)
+    needle = str(os.path.basename(tmpdir))
+
+    matches = find_matches(entriefy({path: 10}), [needle])
+
+    assert list(matches) == list(entriefy({path: 10}))

--- a/tests/unit/autojump_match_test.py
+++ b/tests/unit/autojump_match_test.py
@@ -19,8 +19,8 @@ class TestMatchAnywhere(object):
     entry4 = Entry('/中/zhong/国/guo', 10)
     entry5 = Entry('/is\'t/this/a/b*tchin/edge/case?', 10)
     win_entry1 = Entry('C:\\foo\\bar\\baz', 10)
-    win_entry2 = Entry('D:\Program Files (x86)\GIMP', 10)
-    win_entry3 = Entry('C:\Windows\System32', 10)
+    win_entry2 = Entry('D:\\Program Files (x86)\\GIMP', 10)
+    win_entry3 = Entry('C:\\Windows\\System32', 10)
 
     @pytest.fixture
     def haystack(self):
@@ -75,9 +75,9 @@ class TestMatchConsecutive(object):
     entry4 = Entry('/中/zhong/国/guo', 10)
     entry5 = Entry('/日/本', 10)
     entry6 = Entry('/is\'t/this/a/b*tchin/edge/case?', 10)
-    win_entry1 = Entry('C:\Foo\Bar\Baz', 10)
-    win_entry2 = Entry('D:\Program Files (x86)\GIMP', 10)
-    win_entry3 = Entry('C:\Windows\System32', 10)
+    win_entry1 = Entry('C:\\Foo\\Bar\\Baz', 10)
+    win_entry2 = Entry('D:\\Program Files (x86)\\GIMP', 10)
+    win_entry3 = Entry('C:\\Windows\\System32', 10)
 
     @pytest.fixture
     def haystack(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,6 @@
 [tox]
 envlist =
-    py26,
-    py27,
-    py33,
-    py34,
-    py35
+    py39
 # ignore missing setup.py
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest >= 2.9
 commands =
     coverage run --source=bin/ --omit=bin/autojump_argparse.py -m \
-        py.test -vv -rxs --tb native -s --strict {posargs:tests}
+        py.test -vv -rxs --tb native -s --strict-markers {posargs:tests}
     coverage report -m
 
 


### PR DESCRIPTION
In addition to fixing #348, this removes support for _older_ Python
versions (i.e. other than 3.9) in testing rather rigorously, since I'm
not spending my time on old stuff.

Even though this tool doesn't seem to be maintained anymore, this will
enable the subscribers of #348 to cherry-pick the fix to their forks.
