### PR TITLE
feat: add support for respecting $XDG_DATA_HOME and $AUTOJUMP_DARWIN_XDG on macOS

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -74,19 +74,17 @@ TAB_SEPARATOR = '__'
 def set_defaults():
     config = {}
 
-    if is_osx():
-        data_home = os.path.join(os.path.expanduser('~'), 'Library')
-    elif is_windows():
+    if is_windows():
         data_home = os.getenv('APPDATA')
     else:
-        data_home = os.getenv(
-            'XDG_DATA_HOME',
-            os.path.join(
-                os.path.expanduser('~'),
-                '.local',
-                'share',
-            ),
-        )
+        data_home = os.getenv('XDG_DATA_HOME')
+        if data_home is None:
+            user_home = os.path.expanduser('~')
+            if is_osx() and os.getenv('AUTOJUMP_DARWIN_XDG', '0') == '0':
+                data_home = os.path.join(user_home, 'Library')
+            else:
+                data_home = os.path.join(user_home, '.local', 'share')
+
     config['data_path'] = os.path.join(data_home, 'autojump', 'autojump.txt')
     config['backup_path'] = os.path.join(data_home, 'autojump', 'autojump.txt.bak')
 

--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -7,7 +7,7 @@ fi
 
 
 # set error file location
-if [[ "$(uname)" == "Darwin" ]]; then
+if [[ "$(uname)" == "Darwin" && "${AUTOJUMP_DARWIN_XDG:-0}" == "0" ]]; then
     export AUTOJUMP_ERROR_PATH=~/Library/autojump/errors.log
 elif [[ -n "${XDG_DATA_HOME}" ]]; then
     export AUTOJUMP_ERROR_PATH="${XDG_DATA_HOME}/autojump/errors.log"

--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -16,7 +16,7 @@ complete -x -c j -a '(autojump --complete (commandline -t))'
 
 
 # set error file location
-if test (uname) = "Darwin"
+if test (uname) = "Darwin"; begin; not set -q AUTOJUMP_DARWIN_XDG; or test "$AUTOJUMP_DARWIN_XDG" = "0"; end
     set -gx AUTOJUMP_ERROR_PATH ~/Library/autojump/errors.log
 else if test -d "$XDG_DATA_HOME"
     set -gx AUTOJUMP_ERROR_PATH $XDG_DATA_HOME/autojump/errors.log

--- a/bin/autojump.zsh
+++ b/bin/autojump.zsh
@@ -19,7 +19,7 @@ fi
 
 
 # set error file location
-if [[ "$(uname)" == "Darwin" ]]; then
+if [[ "$(uname)" == "Darwin" && "${AUTOJUMP_DARWIN_XDG:-0}" == "0" ]]; then
     export AUTOJUMP_ERROR_PATH=~/Library/autojump/errors.log
 elif [[ -n "${XDG_DATA_HOME}" ]]; then
     export AUTOJUMP_ERROR_PATH="${XDG_DATA_HOME}/autojump/errors.log"

--- a/bin/autojump_data.py
+++ b/bin/autojump_data.py
@@ -51,16 +51,6 @@ def entriefy(data):
 
 def load(config):
     """Returns a dictonary (key=path, value=weight) loaded from data file."""
-    xdg_aj_home = os.path.join(
-        os.path.expanduser('~'),
-        '.local',
-        'share',
-        'autojump',
-    )
-
-    if is_osx() and os.path.exists(xdg_aj_home):
-        migrate_osx_xdg_data(config)
-
     if not os.path.exists(config['data_path']):
         return {}
 
@@ -93,29 +83,6 @@ def load_backup(config):
         move_file(config['backup_path'], config['data_path'])
         return load(config)
     return {}
-
-
-def migrate_osx_xdg_data(config):
-    """
-    Older versions incorrectly used Linux XDG_DATA_HOME paths on OS X. This
-    migrates autojump files from ~/.local/share/autojump to ~/Library/autojump
-    """
-    assert is_osx(), 'This function should only be run on OS X.'
-
-    xdg_data_home = os.path.join(os.path.expanduser('~'), '.local', 'share')
-    xdg_aj_home = os.path.join(xdg_data_home, 'autojump')
-    data_path = os.path.join(xdg_aj_home, 'autojump.txt')
-    backup_path = os.path.join(xdg_aj_home, 'autojump.txt.bak')
-
-    if os.path.exists(data_path):
-        move_file(data_path, config['data_path'])
-    if os.path.exists(backup_path):
-        move_file(backup_path, config['backup_path'])
-
-    # cleanup
-    shutil.rmtree(xdg_aj_home)
-    if len(os.listdir(xdg_data_home)) == 0:
-        shutil.rmtree(xdg_data_home)
 
 
 def save(config, data):


### PR DESCRIPTION
- respecting a new env `$AUTOJUMP_DARWIN_XDG`: If `$XDG_DATA_HOME` is set, use it as the autojump's data home; else if the OS is macOS and `$AUTOJUMP_DARWIN_XDG` is false, use `~/Library` (for compatibility); otherwise, use XDG's fallback path (i.e., `~/.local/share`).
- remove `migrate_osx_xdg_data()` in autojump_data.py
- related issue: #447