### PR TITLE
Add support for initials detection

### DIFF
--- a/bin/autojump
+++ b/bin/autojump
@@ -50,6 +50,7 @@ from autojump_data import save
 from autojump_match import match_anywhere
 from autojump_match import match_consecutive
 from autojump_match import match_fuzzy
+from autojump_match import match_initials
 from autojump_utils import first
 from autojump_utils import get_pwd
 from autojump_utils import get_tab_entry_info
@@ -200,6 +201,7 @@ def find_matches(entries, needles, check_entries=True):
             match_consecutive(needles, data, ignore_case),
             match_fuzzy(needles, data, ignore_case),
             match_anywhere(needles, data, ignore_case),
+            match_initials(needles, data, ignore_case),
         ),
     )
 

--- a/bin/autojump_match.py
+++ b/bin/autojump_match.py
@@ -127,3 +127,32 @@ def match_fuzzy(needles, haystack, ignore_case=False, threshold=0.6):
         ).ratio()
     meets_threshold = lambda entry: match_percent(entry) >= threshold
     return ifilter(meets_threshold, haystack)
+
+
+def match_initials(needles, haystack, ignore_case=False):
+    """
+    Performs a match of initials anywhere in the path as long as they're in the same (but
+    not necessary consecutive) order.
+
+    For example:
+        needles = ['foo', 'baz']
+        haystack = [
+            (path='/f-o-o/b-a-r/b-a-z', weight=10),
+            (path='/b_a_z/f_o_o/b_a_r', weight=10),
+            (path='/f-o-o/b_a_z', weight=10),
+        ]
+
+        result = [
+            (path='/f-o-o/b-a-r/b-a-z', weight=10),
+            (path='/f-o-o/b_a_z', weight=10),
+        ]
+    """
+    wildcard_needles = imap(lambda n: '.*'.join(list(re.escape(n))), needles)
+    regex_needle = '.*' + '.*'.join(wildcard_needles) + '.*'
+    regex_flags = re.IGNORECASE | re.UNICODE if ignore_case else re.UNICODE
+    found = lambda entry: re.search(
+        regex_needle,
+        entry.path,
+        flags=regex_flags,
+    )
+    return ifilter(found, haystack)


### PR DESCRIPTION
Add support for detection initials (or, more realistically, ordered but non-consecutive partial string matches) on folder names.

For example, the path `/usr/bin/CamelCaseFolder` would be found via:

`j ccf`

Fixes #557