### PR TITLE
Fix manual instructions for current git

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ troubleshoot and submit enhancements and fixes.
 
 Grab a copy of autojump:
 
-    git clone git://github.com/wting/autojump.git
+    git clone https://github.com/wting/autojump
 
 Run the installation script and follow on screen instructions.
 


### PR DESCRIPTION
Unauthenticated attempts to pull git:// URLs now result in error messages, but the https:// URLs work.  See below:

```
$ git clone git://github.com/wting/autojump.git
Cloning into 'autojump'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
$ git clone https://github.com/wting/autojump
Cloning into 'autojump'...
remote: Enumerating objects: 3289, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 3289 (delta 0), reused 1 (delta 0), pack-reused 3280
Receiving objects: 100% (3289/3289), 809.05 KiB | 861.00 KiB/s, done.
Resolving deltas: 100% (1985/1985), done.
$
```