### PR TITLE
correct clone path for repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ troubleshoot and submit enhancements and fixes.
 
 Grab a copy of autojump:
 
-    git clone git://github.com/wting/autojump.git
+    git clone https://github.com/wting/autojump.git
 
 Run the installation script and follow on screen instructions.
 


### PR DESCRIPTION
replace gist with https in the clone path to help in correct cloning of repo for manual installation and setup